### PR TITLE
feat: dynamic Stellar secret key reload

### DIFF
--- a/.kiro/specs/dynamic-secret-key-reload/.config.kiro
+++ b/.kiro/specs/dynamic-secret-key-reload/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a139ae52-709f-482d-9f2b-4eb5ce899d83", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/dynamic-secret-key-reload/design.md
+++ b/.kiro/specs/dynamic-secret-key-reload/design.md
@@ -1,0 +1,647 @@
+# Design Document: Dynamic Secret Key Reload
+
+## Overview
+
+This feature introduces a centralized `SecretManager` module to the StellarFlow Next.js application. Currently, the Stellar Secret Key is read directly from `process.env.STELLAR_SECRET_KEY` at the call site. This design replaces that pattern with a singleton module that holds the key in memory, validates it, and supports hot-reloading via a secure admin HTTP endpoint — without restarting the server.
+
+The design targets Next.js 16 (App Router) with TypeScript. It introduces no new runtime dependencies beyond the AWS SDK v3 client (optional, tree-shaken when unused) and a property-based testing library for correctness verification.
+
+### Key Design Goals
+
+- Single source of truth for the secret key in the Node.js process
+- Atomic, race-condition-free key updates using a promise-based mutex
+- Two key sources: AWS Secrets Manager (primary) and local encrypted file (fallback)
+- Secure admin endpoint with bearer-token authorization
+- Zero breaking changes to existing signing/transaction code
+
+---
+
+## Architecture
+
+### High-Level Component Map
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Next.js App Router (Node.js process)                           │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  secretManager.ts  (singleton)                           │   │
+│  │                                                          │   │
+│  │   inMemoryKey: string  ◄──── atomic swap on update       │   │
+│  │   mutex: AsyncMutex                                      │   │
+│  │                                                          │   │
+│  │   getSecretKey()  ──► returns inMemoryKey (sync)         │   │
+│  │   updateSecretKey(key)  ──► validate → lock → swap       │   │
+│  │   reloadFromSource()  ──► fetch → validate → update      │   │
+│  └──────────────┬───────────────────────────────────────────┘   │
+│                 │                                               │
+│        ┌────────┴────────┐                                      │
+│        ▼                 ▼                                      │
+│  ┌───────────┐   ┌──────────────────┐                          │
+│  │ awsAdapter│   │ fileAdapter.ts   │                          │
+│  │   .ts     │   │ (AES-256-GCM)    │                          │
+│  └─────┬─────┘   └────────┬─────────┘                          │
+│        │                  │                                     │
+│        ▼                  ▼                                     │
+│  AWS Secrets Mgr    Encrypted local file                        │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  POST /admin/reload-secret  (Route Handler)              │   │
+│  │  verifyAdminToken() → secretManager.reloadFromSource()   │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  Existing signing / drip-execution code                  │   │
+│  │  import { getSecretKey } from '@/lib/secretManager'      │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow: Initialization
+
+```
+Server start
+    │
+    ▼
+secretManager.ts module evaluated
+    │
+    ├─ read process.env.STELLAR_SECRET_KEY
+    │       │
+    │       ├─ absent/empty ──► throw StartupError (descriptive, no key value)
+    │       │
+    │       └─ present ──► validate via Validator
+    │                           │
+    │                           ├─ invalid ──► throw StartupError
+    │                           │
+    │                           └─ valid ──► store as inMemoryKey
+    │
+    └─ module ready; getSecretKey() available
+```
+
+### Data Flow: Hot Reload
+
+```
+POST /admin/reload-secret
+    │
+    ├─ verifyAdminToken(request)
+    │       │
+    │       ├─ missing/invalid ──► HTTP 401 (no key fetch)
+    │       │
+    │       └─ valid ──► continue
+    │
+    ▼
+secretManager.reloadFromSource()
+    │
+    ├─ AWS_SECRET_ARN set?
+    │       ├─ yes ──► awsAdapter.fetchKey()
+    │       │               │
+    │       │               ├─ success ──► rawKey
+    │       │               └─ failure ──► retain inMemoryKey, return error
+    │       │
+    │       └─ no ──► fileAdapter.fetchKey()
+    │                       │
+    │                       ├─ success ──► rawKey
+    │                       └─ failure ──► retain inMemoryKey, return error
+    │
+    ▼
+Validator.validate(rawKey)
+    │
+    ├─ invalid ──► retain inMemoryKey, log failure (no key), return error
+    │
+    └─ valid ──► secretManager.updateSecretKey(rawKey)
+                        │
+                        ├─ acquire mutex
+                        ├─ overwrite inMemoryKey
+                        ├─ release mutex
+                        └─ emit audit log (timestamp, adminId, "success")
+    │
+    └─ HTTP 200 { message: "Key reloaded successfully" }
+```
+
+---
+
+## Components and Interfaces
+
+### `src/lib/secretManager.ts`
+
+The singleton module. Initialized once when the module is first imported.
+
+```typescript
+// Public interface
+export function getSecretKey(): string
+export async function updateSecretKey(newKey: string): Promise<UpdateResult>
+export async function reloadFromSource(): Promise<ReloadResult>
+
+// Internal
+type UpdateResult = { success: true } | { success: false; error: string }
+type ReloadResult = { success: true } | { success: false; error: string }
+```
+
+**Initialization behavior:**
+- On module load, reads `process.env.STELLAR_SECRET_KEY`
+- Validates via `Validator.validate()`
+- Throws `SecretManagerInitError` if absent, empty, or invalid
+
+**`getSecretKey()`:**
+- Synchronous — reads the current `inMemoryKey` reference
+- No locking needed (JS single-threaded reads; atomic reference swap on write)
+
+**`updateSecretKey(newKey)`:**
+- Validates the candidate key first (before acquiring the lock)
+- If same as current key → returns `{ success: true }` immediately (no-op)
+- Acquires the async mutex
+- Overwrites `inMemoryKey`
+- Releases mutex
+- Emits audit log entry
+
+**`reloadFromSource()`:**
+- Selects adapter based on env vars
+- Fetches raw key
+- Calls `updateSecretKey()` with the result
+
+---
+
+### `src/lib/validator.ts`
+
+```typescript
+import { Keypair } from '@stellar/stellar-sdk'
+
+export function validate(candidate: string): ValidationResult
+
+type ValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string }  // reason never contains the key value
+```
+
+Uses `Keypair.fromSecret(candidate)` inside a try/catch. A valid Stellar secret key starts with `S` and passes the SDK's internal checksum. The `reason` field in failure results describes the structural problem (e.g., "does not begin with 'S'", "checksum failed") without echoing the candidate value.
+
+---
+
+### `src/lib/adapters/awsAdapter.ts`
+
+```typescript
+export async function fetchKey(): Promise<FetchResult>
+
+type FetchResult =
+  | { success: true; key: string }
+  | { success: false; error: string }
+```
+
+- Uses `@aws-sdk/client-secrets-manager` (`GetSecretValueCommand`)
+- Secret ARN read from `process.env.AWS_SECRET_ARN`
+- Expects the secret value to be a plain string (the raw Stellar key)
+- Errors are caught and returned as structured failures — never thrown to callers
+- The fetched key is never logged
+
+---
+
+### `src/lib/adapters/fileAdapter.ts`
+
+```typescript
+export async function fetchKey(): Promise<FetchResult>
+```
+
+- Reads the encrypted file at `process.env.SECRET_FILE_PATH`
+- Decrypts using AES-256-GCM with key material from `process.env.FILE_ENCRYPTION_KEY`
+- File format: `<12-byte IV hex>:<16-byte auth tag hex>:<ciphertext hex>`
+- Returns the decrypted plaintext Stellar key
+- Errors (file not found, decryption failure) returned as structured failures
+
+---
+
+### `src/lib/mutex.ts`
+
+A minimal promise-based async mutex for Node.js (no external dependency needed):
+
+```typescript
+export class AsyncMutex {
+  acquire(): Promise<() => void>  // returns a release function
+}
+```
+
+Internally maintains a promise chain. `acquire()` returns a promise that resolves to a `release` function. Callers must call `release()` in a `finally` block.
+
+---
+
+### `src/app/api/admin/reload-secret/route.ts`
+
+Next.js App Router route handler.
+
+```typescript
+export async function POST(request: Request): Promise<Response>
+```
+
+**Auth verification:**
+- Reads `Authorization: Bearer <token>` header
+- Compares against `process.env.ADMIN_RELOAD_TOKEN` using `crypto.timingSafeEqual` to prevent timing attacks
+- Returns `Response` with status 401 if missing or mismatched
+
+**Success response:**
+```json
+{ "message": "Key reloaded successfully", "timestamp": "2024-01-01T00:00:00.000Z" }
+```
+
+**Failure response:**
+```json
+{ "error": "Reload failed: <reason>", "timestamp": "2024-01-01T00:00:00.000Z" }
+```
+
+Neither response includes the key value.
+
+---
+
+### `src/lib/auditLogger.ts`
+
+```typescript
+export function logReloadEvent(event: AuditEvent): void
+
+interface AuditEvent {
+  timestamp: string       // ISO 8601
+  adminIdentity: string   // from token or request header
+  outcome: 'success' | 'failure'
+  failureReason?: string  // never contains key value
+}
+```
+
+Writes structured JSON to `console.log` (captured by the hosting platform's log aggregator). The implementation explicitly strips any string that matches the current key before writing.
+
+---
+
+## Data Models
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `STELLAR_SECRET_KEY` | Yes (startup) | Fallback/initial key; used if no source fetch has occurred |
+| `AWS_SECRET_ARN` | No | If set, AWS adapter is used as primary source |
+| `SECRET_FILE_PATH` | No | Path to local encrypted key file (fallback) |
+| `FILE_ENCRYPTION_KEY` | If `SECRET_FILE_PATH` set | Hex-encoded 32-byte AES-256 key |
+| `ADMIN_RELOAD_TOKEN` | Yes | Bearer token for reload endpoint authorization |
+
+### In-Memory State (secretManager.ts)
+
+```typescript
+let inMemoryKey: string          // current active key
+const mutex = new AsyncMutex()   // serializes writes
+```
+
+### Audit Log Entry (JSON)
+
+```json
+{
+  "event": "secret_key_reload",
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "adminIdentity": "admin-token-prefix-****",
+  "outcome": "success" | "failure",
+  "failureReason": "optional, no key value"
+}
+```
+
+---
+
+## Concurrency and Locking Strategy
+
+JavaScript's event loop is single-threaded, so simple variable reads are inherently atomic. However, `updateSecretKey` involves an async fetch-then-write sequence that must be serialized.
+
+**Strategy: Copy-on-write with async mutex**
+
+1. `getSecretKey()` reads `inMemoryKey` synchronously — no lock needed. It always returns the last fully committed value.
+2. `updateSecretKey()` acquires the mutex before writing. If two concurrent calls arrive:
+   - The first acquires the mutex and proceeds
+   - The second awaits the mutex; when released, it runs with the latest state
+3. The mutex is released in a `finally` block to prevent deadlocks on error
+4. The key reference is replaced atomically (single assignment) — no partial state is possible
+
+```
+Timeline:
+  t=0  reload-A acquires mutex, begins fetch
+  t=1  reload-B arrives, awaits mutex
+  t=2  reload-A completes, writes keyA, releases mutex
+  t=3  reload-B acquires mutex, begins fetch (sees keyA as current)
+  t=4  reload-B completes, writes keyB, releases mutex
+
+  getSecretKey() at any point returns: initial → keyA → keyB
+  Never returns a partial/undefined value.
+```
+
+---
+
+## AWS Secrets Manager Integration
+
+### IAM Permissions (minimum required)
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["secretsmanager:GetSecretValue"],
+  "Resource": "arn:aws:secretsmanager:<region>:<account>:secret:<secret-name>-*"
+}
+```
+
+No `DescribeSecret`, `ListSecrets`, `RotateSecret`, or write permissions are needed.
+
+### Key Rotation Handling
+
+AWS Secrets Manager supports automatic rotation. When rotation occurs, the new version is tagged `AWSCURRENT`. The `GetSecretValueCommand` without a `VersionStage` parameter always returns `AWSCURRENT`. The reload endpoint triggers a fresh `GetSecretValueCommand` call, so the next reload after rotation will pick up the new key automatically — no special rotation event handling is needed.
+
+### Local Encrypted File Fallback
+
+Used when `AWS_SECRET_ARN` is not set. The file is encrypted at rest using AES-256-GCM:
+
+```
+File format (text):
+<iv_hex>:<authTag_hex>:<ciphertext_hex>
+
+Example:
+a1b2c3d4e5f6a7b8c9d0e1f2:deadbeef...:<encrypted_key_hex>
+```
+
+The encryption key (`FILE_ENCRYPTION_KEY`) must be stored separately from the file (e.g., in a secrets vault or environment variable injected at deploy time).
+
+---
+
+## Admin Auth for the Reload Endpoint
+
+The endpoint uses a static bearer token stored in `ADMIN_RELOAD_TOKEN`. This is appropriate for internal/ops tooling where a full OAuth flow would be over-engineered.
+
+**Security properties of the auth check:**
+- `crypto.timingSafeEqual` prevents timing-based token enumeration
+- Token is compared as `Buffer` (byte-level), not string equality
+- A missing `Authorization` header returns 401 before any key fetch occurs
+- The token value is never logged
+
+**Hardening recommendations (noted in design, not implemented here):**
+- Rotate `ADMIN_RELOAD_TOKEN` on a schedule
+- Restrict the `/admin/*` path at the infrastructure level (e.g., ALB rule, VPC-only)
+- Consider adding IP allowlisting at the reverse proxy layer
+
+---
+
+## Security Considerations
+
+1. **Key never in logs**: `auditLogger.ts` scrubs the key from all output. `validator.ts` returns structural error descriptions, not the candidate value. All error types are designed to carry context without carrying the key.
+
+2. **Timing-safe comparison**: The admin token check uses `crypto.timingSafeEqual` to prevent oracle attacks.
+
+3. **Minimal AWS permissions**: The IAM policy grants only `GetSecretValue` on the specific secret ARN.
+
+4. **Encrypted file at rest**: The local fallback file is AES-256-GCM encrypted. The decryption key is never stored alongside the file.
+
+5. **No key in HTTP responses**: Both success and failure responses from the reload endpoint are templated to contain only status messages and timestamps.
+
+6. **Startup validation**: An invalid or missing key at startup causes a hard crash with a descriptive error — preventing the server from running in a broken state silently.
+
+7. **Mutex prevents partial state**: The async mutex ensures no consumer ever reads a half-written key value.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| `STELLAR_SECRET_KEY` missing at startup | Throw `SecretManagerInitError` with descriptive message (no key value) |
+| Invalid key at startup | Throw `SecretManagerInitError` with validation failure reason |
+| `updateSecretKey` called with invalid key | Return `{ success: false, error: "Invalid key format: ..." }`, key unchanged |
+| AWS fetch fails (network, permissions) | Return `{ success: false, error: "AWS fetch failed: ..." }`, key unchanged |
+| File read/decrypt fails | Return `{ success: false, error: "File fetch failed: ..." }`, key unchanged |
+| Reload endpoint: missing/invalid token | HTTP 401 `{ error: "Unauthorized" }` |
+| Reload endpoint: reload fails | HTTP 500 `{ error: "Reload failed: <reason>" }` |
+| Mutex deadlock (should not occur) | `finally` block guarantees release; if mutex is never acquired, request times out at the HTTP layer |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Key update round-trip
+
+*For any* valid Stellar secret key `k`, after calling `updateSecretKey(k)` successfully, `getSecretKey()` must return `k`.
+
+**Validates: Requirements 1.2, 5.3, 7.4**
+
+---
+
+### Property 2: Invalid key rejected, state preserved
+
+*For any* string that is not a valid Stellar secret key, calling `updateSecretKey` must return a failure result, and `getSecretKey()` must return the same value it returned before the call.
+
+**Validates: Requirements 2.1, 2.2**
+
+---
+
+### Property 3: Same-key update is a no-op
+
+*For any* valid Stellar secret key `k` already stored as the current key, calling `updateSecretKey(k)` must return a success result and `getSecretKey()` must still return `k`.
+
+**Validates: Requirements 2.3**
+
+---
+
+### Property 4: Fetch failure preserves existing key
+
+*For any* key source that returns a failure, calling `reloadFromSource()` must return a failure result and `getSecretKey()` must return the same key it returned before the reload attempt.
+
+**Validates: Requirements 3.4**
+
+---
+
+### Property 5: Fetched key passes through validator
+
+*For any* key source that returns an invalid Stellar key string, calling `reloadFromSource()` must return a failure result and `getSecretKey()` must be unchanged.
+
+**Validates: Requirements 3.3**
+
+---
+
+### Property 6: Caching prevents redundant external calls
+
+*For any* sequence of `getSecretKey()` calls after a successful fetch, the external key source adapter must be called at most once per `reloadFromSource()` invocation.
+
+**Validates: Requirements 3.5**
+
+---
+
+### Property 7: Unauthorized requests rejected, key unchanged
+
+*For any* HTTP request to `POST /admin/reload-secret` that carries an absent or incorrect authorization token, the response status must be 401 and `getSecretKey()` must return the same value it returned before the request.
+
+**Validates: Requirements 4.2, 4.3**
+
+---
+
+### Property 8: Response body never contains the key value
+
+*For any* outcome of a reload request (success or failure), the HTTP response body must not contain the current or previous secret key value as a substring.
+
+**Validates: Requirements 4.5, 4.6, 1.5, 7.1, 8.2, 8.3**
+
+---
+
+### Property 9: Concurrent updates are serialized, no partial state
+
+*For any* set of concurrent `updateSecretKey` calls with distinct valid keys, after all calls complete, `getSecretKey()` must return exactly one of the supplied keys — never `undefined`, never a concatenation, never an empty string.
+
+**Validates: Requirements 5.1, 5.4**
+
+---
+
+### Property 10: Reads during update return a valid key without blocking
+
+*For any* `updateSecretKey` call in progress, concurrent `getSecretKey()` calls must return a non-empty string (either the previous key or the new key) and must not block indefinitely.
+
+**Validates: Requirements 5.2**
+
+---
+
+### Property 11: Audit log contains required fields
+
+*For any* reload event (success or failure), the emitted audit log entry must contain a valid ISO 8601 timestamp, an admin identity string, and an outcome field — and must not contain the secret key value as a substring.
+
+**Validates: Requirements 8.1, 8.2**
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit/integration tests and property-based tests are required. They are complementary:
+
+- **Unit/integration tests** verify specific examples, edge cases, and integration points (e.g., "given this exact env var, the module initializes correctly")
+- **Property-based tests** verify universal invariants across randomly generated inputs (e.g., "for any invalid string, the key is never corrupted")
+
+### Property-Based Testing Library
+
+**Library**: [`fast-check`](https://github.com/dubzzz/fast-check) — the standard PBT library for TypeScript/JavaScript.
+
+Install: `npm install --save-dev fast-check`
+
+Each property test must run a minimum of **100 iterations** (fast-check default is 100; set explicitly via `{ numRuns: 100 }`).
+
+Each test must include a comment referencing the design property it validates:
+```
+// Feature: dynamic-secret-key-reload, Property N: <property text>
+```
+
+### Unit / Integration Tests
+
+Framework: **Jest** (already standard in Next.js projects) or **Vitest**.
+
+| Test | Type | Covers |
+|---|---|---|
+| Init with valid env var → `getSecretKey()` returns it | example | Req 1.3, 6.1 |
+| Init with missing env var → throws `SecretManagerInitError` | edge-case | Req 1.4 |
+| Init with empty string env var → throws | edge-case | Req 1.4 |
+| `reloadFromSource()` with AWS adapter mock → calls `GetSecretValueCommand` | example | Req 3.1 |
+| `reloadFromSource()` with AWS failure → falls back to file adapter | example | Req 3.2 |
+| `POST /admin/reload-secret` with valid token → HTTP 200 | example | Req 4.1, 4.4 |
+| `POST /admin/reload-secret` with no token → HTTP 401 | adversarial | Req 4.3 |
+| `POST /admin/reload-secret` with wrong token → HTTP 401 | adversarial | Req 4.3 |
+| Reload with malformed key from source → key unchanged | adversarial | Req 9.4 |
+| AWS rotation: mock returns new key on second call → reload picks it up | example | Req 7.3 |
+| Concurrent reload + signing: final key is consistent | concurrency | Req 9.5 |
+
+### Property-Based Tests
+
+Each property below maps to a design property and must be implemented as a single `fast-check` test.
+
+```typescript
+// Property 1: Key update round-trip
+// Feature: dynamic-secret-key-reload, Property 1: key update round-trip
+fc.assert(fc.asyncProperty(validStellarKeyArbitrary(), async (key) => {
+  await updateSecretKey(key)
+  return getSecretKey() === key
+}), { numRuns: 100 })
+
+// Property 2: Invalid key rejected, state preserved
+// Feature: dynamic-secret-key-reload, Property 2: invalid key rejected
+fc.assert(fc.asyncProperty(invalidKeyArbitrary(), async (badKey) => {
+  const before = getSecretKey()
+  const result = await updateSecretKey(badKey)
+  return result.success === false && getSecretKey() === before
+}), { numRuns: 100 })
+
+// Property 3: Same-key update is a no-op
+// Feature: dynamic-secret-key-reload, Property 3: same-key no-op
+fc.assert(fc.asyncProperty(validStellarKeyArbitrary(), async (key) => {
+  await updateSecretKey(key)
+  const result = await updateSecretKey(key)
+  return result.success === true && getSecretKey() === key
+}), { numRuns: 100 })
+
+// Property 4: Fetch failure preserves existing key
+// Feature: dynamic-secret-key-reload, Property 4: fetch failure preserves key
+fc.assert(fc.asyncProperty(fc.anything(), async () => {
+  const before = getSecretKey()
+  mockAdapterToFail()
+  const result = await reloadFromSource()
+  return result.success === false && getSecretKey() === before
+}), { numRuns: 100 })
+
+// Property 7: Unauthorized requests rejected
+// Feature: dynamic-secret-key-reload, Property 7: unauthorized rejected
+fc.assert(fc.asyncProperty(fc.string(), async (token) => {
+  fc.pre(token !== process.env.ADMIN_RELOAD_TOKEN)
+  const before = getSecretKey()
+  const res = await POST(makeRequest(token))
+  return res.status === 401 && getSecretKey() === before
+}), { numRuns: 100 })
+
+// Property 8: Response body never contains key
+// Feature: dynamic-secret-key-reload, Property 8: response never leaks key
+fc.assert(fc.asyncProperty(fc.boolean(), async (shouldSucceed) => {
+  setupMock(shouldSucceed)
+  const res = await POST(makeAuthorizedRequest())
+  const body = await res.text()
+  return !body.includes(getSecretKey())
+}), { numRuns: 100 })
+
+// Property 9: Concurrent updates produce no partial state
+// Feature: dynamic-secret-key-reload, Property 9: concurrent updates serialized
+fc.assert(fc.asyncProperty(
+  fc.array(validStellarKeyArbitrary(), { minLength: 2, maxLength: 10 }),
+  async (keys) => {
+    await Promise.all(keys.map(k => updateSecretKey(k)))
+    const final = getSecretKey()
+    return keys.includes(final)
+  }
+), { numRuns: 100 })
+
+// Property 11: Audit log contains required fields, no key value
+// Feature: dynamic-secret-key-reload, Property 11: audit log fields
+fc.assert(fc.asyncProperty(validStellarKeyArbitrary(), async (key) => {
+  const logs: AuditEvent[] = []
+  captureAuditLogs(logs)
+  await updateSecretKey(key)
+  const entry = logs[logs.length - 1]
+  return (
+    typeof entry.timestamp === 'string' &&
+    typeof entry.adminIdentity === 'string' &&
+    (entry.outcome === 'success' || entry.outcome === 'failure') &&
+    !JSON.stringify(entry).includes(key)
+  )
+}), { numRuns: 100 })
+```
+
+### Arbitraries
+
+```typescript
+// Generates valid Stellar secret keys using the SDK
+function validStellarKeyArbitrary() {
+  return fc.nat().map(() => Keypair.random().secret())
+}
+
+// Generates strings that are NOT valid Stellar keys
+function invalidKeyArbitrary() {
+  return fc.oneof(
+    fc.string(),                          // random strings
+    fc.constant(''),                      // empty
+    fc.constant('GNOTASECRETKEY'),        // starts with G (public key)
+    fc.hexaString({ minLength: 56 })      // wrong format
+  ).filter(s => {
+    try { Keypair.fromSecret(s); return false } catch { return true }
+  })
+}
+```

--- a/.kiro/specs/dynamic-secret-key-reload/requirements.md
+++ b/.kiro/specs/dynamic-secret-key-reload/requirements.md
@@ -1,0 +1,136 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds dynamic runtime reloading of the Stellar Secret Key in the StellarFlow application. Currently the key is loaded once from `.env` at server startup. The goal is to allow the key to be updated without restarting the server, while preserving security, consistency, and backward compatibility with all existing signing and transaction flows.
+
+## Glossary
+
+- **Secret_Manager**: The centralized module (`secretManager.ts`) responsible for storing, retrieving, and updating the Stellar Secret Key in memory.
+- **Secret_Key**: The Stellar secret key (seed) used to sign transactions, formatted as a Stellar-compatible base58-encoded string beginning with `S`.
+- **Reload_Endpoint**: The HTTP API endpoint (`POST /admin/reload-secret`) that triggers a runtime key refresh.
+- **Key_Source**: The origin from which the Secret_Key is fetched — either AWS Secrets Manager or a local encrypted file fallback.
+- **Admin_Client**: An authenticated caller with admin-level authorization permitted to trigger key reloads.
+- **Validator**: The component responsible for verifying that a candidate Secret_Key is well-formed and valid before it is applied.
+- **Lock**: A mutual-exclusion mechanism that prevents concurrent reads and writes to the in-memory Secret_Key during an update.
+
+---
+
+## Requirements
+
+### Requirement 1: Centralized Secret Manager
+
+**User Story:** As a backend developer, I want all secret key access to go through a single module, so that key management logic is not scattered across the codebase.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL expose a `getSecretKey()` function that returns the current in-memory Secret_Key.
+2. THE Secret_Manager SHALL expose an `updateSecretKey(newKey: string)` function that replaces the in-memory Secret_Key.
+3. THE Secret_Manager SHALL initialize the in-memory Secret_Key from the `STELLAR_SECRET_KEY` environment variable on first load.
+4. IF `STELLAR_SECRET_KEY` is absent or empty at initialization, THEN THE Secret_Manager SHALL throw a descriptive startup error.
+5. THE Secret_Manager SHALL never expose the raw Secret_Key value in log output, error messages, or serialized responses.
+
+---
+
+### Requirement 2: Secret Key Validation
+
+**User Story:** As a security engineer, I want every candidate key to be validated before it is applied, so that malformed or invalid keys never enter the system.
+
+#### Acceptance Criteria
+
+1. WHEN `updateSecretKey` is called, THE Validator SHALL verify that the candidate key is a valid Stellar secret key (begins with `S`, passes Stellar SDK key-pair validation).
+2. IF the candidate key fails validation, THEN THE Secret_Manager SHALL reject the update and return a structured error without modifying the current in-memory Secret_Key.
+3. IF the candidate key is identical to the current in-memory Secret_Key, THEN THE Secret_Manager SHALL accept the call as a no-op and return a success response.
+
+---
+
+### Requirement 3: Key Source Integration
+
+**User Story:** As an operator, I want the secret key to be fetchable from a secure external source, so that key rotation can happen without manual file edits.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL support fetching the Secret_Key from AWS Secrets Manager when the `AWS_SECRET_ARN` environment variable is set.
+2. WHERE AWS Secrets Manager is unavailable, THE Secret_Manager SHALL fall back to reading the Secret_Key from a local encrypted file whose path is specified by the `SECRET_FILE_PATH` environment variable.
+3. WHEN a fetch from the Key_Source succeeds, THE Secret_Manager SHALL pass the retrieved value through the Validator before applying it.
+4. IF a fetch from the Key_Source fails, THEN THE Secret_Manager SHALL retain the existing in-memory Secret_Key and return a structured error describing the failure.
+5. THE Secret_Manager SHALL cache the fetched Secret_Key in memory to avoid redundant external calls on every signing operation.
+
+---
+
+### Requirement 4: Hot Reload API Endpoint
+
+**User Story:** As an admin operator, I want a secure HTTP endpoint to trigger a key reload, so that I can rotate the secret key at runtime without restarting the server.
+
+#### Acceptance Criteria
+
+1. THE Reload_Endpoint SHALL accept `POST /admin/reload-secret` requests.
+2. WHEN a request is received at `POST /admin/reload-secret`, THE Reload_Endpoint SHALL verify that the request carries a valid admin authorization token before proceeding.
+3. IF the authorization token is absent or invalid, THEN THE Reload_Endpoint SHALL return HTTP 401 and SHALL NOT trigger a key reload.
+4. WHEN authorization succeeds, THE Reload_Endpoint SHALL instruct the Secret_Manager to fetch the latest Secret_Key from the Key_Source and apply it.
+5. WHEN the reload completes successfully, THE Reload_Endpoint SHALL return HTTP 200 with a confirmation message that does not include the Secret_Key value.
+6. IF the reload fails for any reason, THEN THE Reload_Endpoint SHALL return HTTP 500 with a structured error message that does not include the Secret_Key value.
+
+---
+
+### Requirement 5: Concurrency and Atomic Updates
+
+**User Story:** As a backend developer, I want key updates to be atomic and race-condition-free, so that no transaction is signed with a partially updated or inconsistent key.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL use a Lock to serialize concurrent calls to `updateSecretKey`.
+2. WHILE a key update is in progress, THE Secret_Manager SHALL allow concurrent `getSecretKey()` calls to return the previous valid Secret_Key without blocking.
+3. WHEN the Lock is released after a successful update, THE Secret_Manager SHALL guarantee that all subsequent `getSecretKey()` calls return the new Secret_Key.
+4. IF two concurrent reload requests arrive simultaneously, THEN THE Secret_Manager SHALL process them sequentially and SHALL NOT produce a partial state.
+
+---
+
+### Requirement 6: Backward Compatibility
+
+**User Story:** As a developer, I want existing transaction signing and drip execution flows to continue working without modification, so that the feature introduces no breaking changes.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL provide a `getSecretKey()` interface that is a drop-in replacement for direct `process.env.STELLAR_SECRET_KEY` access.
+2. WHEN existing signing or drip-execution code calls `getSecretKey()`, THE Secret_Manager SHALL return the current valid Secret_Key synchronously or via a resolved Promise, matching the call pattern used by the caller.
+3. THE Secret_Manager SHALL not alter any public API signatures, route handlers, or exported types that are consumed outside the secret management module.
+
+---
+
+### Requirement 7: Security Constraints
+
+**User Story:** As a security engineer, I want the secret key to be handled securely in memory and never exposed through observable channels, so that the risk of key leakage is minimized.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL never write the Secret_Key to any log, console output, HTTP response body, or error stack trace.
+2. WHERE AWS Secrets Manager is used, THE Secret_Manager SHALL use an IAM role or policy that grants only the minimum permissions required to read the target secret.
+3. WHEN a key rotation event occurs in AWS Secrets Manager, THE Secret_Manager SHALL handle the rotation gracefully by fetching the new version without service interruption.
+4. THE Secret_Manager SHALL overwrite the previous in-memory Secret_Key value immediately after a successful update to minimize the window during which both values coexist in memory.
+
+---
+
+### Requirement 8: Observability and Audit Logging
+
+**User Story:** As an operator, I want reload events to be logged with enough detail to audit who triggered them and whether they succeeded, so that I can investigate incidents.
+
+#### Acceptance Criteria
+
+1. WHEN a reload is triggered via the Reload_Endpoint, THE Secret_Manager SHALL emit a structured log entry containing: timestamp, triggering admin identity, and outcome (success or failure reason).
+2. THE Secret_Manager SHALL never include the Secret_Key value or any portion of it in audit log entries.
+3. IF a reload attempt fails validation, THEN THE Secret_Manager SHALL log the failure reason without including the rejected key value.
+
+---
+
+### Requirement 9: Testing Coverage
+
+**User Story:** As a developer, I want comprehensive tests for the secret management feature, so that regressions are caught early and the implementation is trustworthy.
+
+#### Acceptance Criteria
+
+1. THE Secret_Manager SHALL have unit tests covering: successful `getSecretKey()` retrieval, successful `updateSecretKey()` with a valid key, rejection of an invalid key, and no-op behavior when the same key is supplied.
+2. THE Secret_Manager SHALL have integration tests verifying that a key updated during active signing operations causes all subsequent operations to use the new key.
+3. THE Reload_Endpoint SHALL have adversarial tests verifying that requests without valid authorization tokens are rejected with HTTP 401.
+4. THE Reload_Endpoint SHALL have adversarial tests verifying that supplying a malformed key via the reload flow does not corrupt the in-memory Secret_Key.
+5. THE Secret_Manager SHALL have concurrency tests verifying that simultaneous reload and signing operations do not produce race conditions or partial state.

--- a/.kiro/specs/dynamic-secret-key-reload/tasks.md
+++ b/.kiro/specs/dynamic-secret-key-reload/tasks.md
@@ -1,0 +1,206 @@
+# Implementation Plan: Dynamic Secret Key Reload
+
+## Overview
+
+Implement a centralized `SecretManager` singleton for the StellarFlow Next.js application that holds the Stellar secret key in memory, validates it, supports hot-reloading via a secure admin endpoint, and integrates with AWS Secrets Manager and a local encrypted file fallback — all without breaking existing signing flows.
+
+## Tasks
+
+- [x] 1. Install dependencies and set up project structure
+  - Run `npm install --save-dev fast-check` to add the property-based testing library
+  - Run `npm install @aws-sdk/client-secrets-manager` to add the AWS SDK client
+  - Create directory `src/lib/adapters/` for the adapter modules
+  - Create directory `src/app/api/admin/reload-secret/` for the route handler
+  - _Requirements: 1.1, 3.1_
+
+- [x] 2. Implement `AsyncMutex` and `Validator`
+  - [x] 2.1 Create `src/lib/mutex.ts` with the `AsyncMutex` class
+    - Implement promise-chain-based `acquire(): Promise<() => void>` that returns a release function
+    - Callers must use `release()` in a `finally` block
+    - _Requirements: 5.1, 5.4_
+
+  - [ ]* 2.2 Write unit tests for `AsyncMutex`
+    - Test that concurrent acquires are serialized
+    - Test that release in `finally` prevents deadlock
+    - _Requirements: 5.1, 5.4_
+
+  - [x] 2.3 Create `src/lib/validator.ts` with `validate(candidate: string): ValidationResult`
+    - Use `Keypair.fromSecret()` from `@stellar/stellar-sdk` inside a try/catch
+    - Return `{ valid: true }` on success; `{ valid: false; reason: string }` on failure
+    - The `reason` field must never echo the candidate key value
+    - _Requirements: 2.1, 2.2, 7.1_
+
+  - [ ]* 2.4 Write property test for `Validator` — Property 2: Invalid key rejected
+    - **Property 2: Invalid key rejected, state preserved**
+    - **Validates: Requirements 2.1, 2.2**
+    - Use `invalidKeyArbitrary()` to generate non-Stellar strings; assert `validate()` returns `{ valid: false }`
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 2`
+
+- [x] 3. Implement `SecretManager` singleton
+  - [x] 3.1 Create `src/lib/secretManager.ts` with module-level `inMemoryKey` and `AsyncMutex` instance
+    - On module load, read `process.env.STELLAR_SECRET_KEY`, validate it, and store as `inMemoryKey`
+    - Throw `SecretManagerInitError` if the env var is absent, empty, or fails validation
+    - _Requirements: 1.3, 1.4_
+
+  - [x] 3.2 Implement `getSecretKey(): string`
+    - Synchronous read of `inMemoryKey` — no locking required
+    - _Requirements: 1.1, 6.1, 6.2_
+
+  - [x] 3.3 Implement `updateSecretKey(newKey: string): Promise<UpdateResult>`
+    - Validate candidate before acquiring the mutex
+    - If candidate equals current key, return `{ success: true }` immediately (no-op)
+    - Acquire mutex, overwrite `inMemoryKey`, release mutex in `finally`
+    - Emit audit log entry via `auditLogger.ts` after successful update
+    - _Requirements: 1.2, 2.2, 2.3, 5.1, 5.3, 7.4_
+
+  - [ ]* 3.4 Write property test for `SecretManager` — Property 1: Key update round-trip
+    - **Property 1: Key update round-trip**
+    - **Validates: Requirements 1.2, 5.3, 7.4**
+    - Use `validStellarKeyArbitrary()`; after `updateSecretKey(k)`, assert `getSecretKey() === k`
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 1`
+
+  - [ ]* 3.5 Write property test for `SecretManager` — Property 3: Same-key update is a no-op
+    - **Property 3: Same-key update is a no-op**
+    - **Validates: Requirements 2.3**
+    - Set key to `k`, call `updateSecretKey(k)` again, assert `success === true` and key unchanged
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 3`
+
+  - [ ]* 3.6 Write property test for `SecretManager` — Property 9: Concurrent updates produce no partial state
+    - **Property 9: Concurrent updates are serialized, no partial state**
+    - **Validates: Requirements 5.1, 5.4**
+    - Fire `Promise.all` of multiple `updateSecretKey` calls; assert final key is one of the supplied keys
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 9`
+
+  - [ ]* 3.7 Write property test for `SecretManager` — Property 10: Reads during update return a valid key
+    - **Property 10: Reads during update return a valid key without blocking**
+    - **Validates: Requirements 5.2**
+    - While `updateSecretKey` is in progress, assert `getSecretKey()` returns a non-empty string
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 10`
+
+- [x] 4. Implement `AuditLogger`
+  - [x] 4.1 Create `src/lib/auditLogger.ts` with `logReloadEvent(event: AuditEvent): void`
+    - Write structured JSON to `console.log`
+    - Strip any substring matching the current key before writing
+    - Include fields: `event`, `timestamp` (ISO 8601), `adminIdentity`, `outcome`, optional `failureReason`
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [ ]* 4.2 Write property test for `AuditLogger` — Property 11: Audit log contains required fields
+    - **Property 11: Audit log contains required fields, no key value**
+    - **Validates: Requirements 8.1, 8.2**
+    - For any reload event, assert log entry has `timestamp`, `adminIdentity`, `outcome`, and does not contain the key
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 11`
+
+- [x] 5. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Implement key source adapters
+  - [x] 6.1 Create `src/lib/adapters/awsAdapter.ts` with `fetchKey(): Promise<FetchResult>`
+    - Use `@aws-sdk/client-secrets-manager` `GetSecretValueCommand`
+    - Read ARN from `process.env.AWS_SECRET_ARN`
+    - Catch all errors and return `{ success: false; error: string }` — never throw to callers
+    - Never log the fetched key value
+    - _Requirements: 3.1, 7.1, 7.2_
+
+  - [ ]* 6.2 Write unit tests for `awsAdapter`
+    - Mock `GetSecretValueCommand`; test success path returns key string
+    - Test network/permission failure returns structured error
+    - _Requirements: 3.1, 3.4_
+
+  - [x] 6.3 Create `src/lib/adapters/fileAdapter.ts` with `fetchKey(): Promise<FetchResult>`
+    - Read encrypted file at `process.env.SECRET_FILE_PATH`
+    - Decrypt using AES-256-GCM with key from `process.env.FILE_ENCRYPTION_KEY`
+    - File format: `<iv_hex>:<authTag_hex>:<ciphertext_hex>`
+    - Return structured failure on file-not-found or decryption error
+    - _Requirements: 3.2, 7.1_
+
+  - [ ]* 6.4 Write unit tests for `fileAdapter`
+    - Test successful decrypt returns plaintext key
+    - Test missing file returns structured error
+    - Test bad auth tag (tampered file) returns structured error
+    - _Requirements: 3.2, 3.4_
+
+- [x] 7. Implement `reloadFromSource` in `SecretManager`
+  - [x] 7.1 Add `reloadFromSource(): Promise<ReloadResult>` to `src/lib/secretManager.ts`
+    - Select adapter: use `awsAdapter` if `AWS_SECRET_ARN` is set, else `fileAdapter`
+    - On fetch failure, retain `inMemoryKey` and return structured error
+    - On fetch success, pass result through `Validator` before calling `updateSecretKey`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [ ]* 7.2 Write property test for `SecretManager` — Property 4: Fetch failure preserves existing key
+    - **Property 4: Fetch failure preserves existing key**
+    - **Validates: Requirements 3.4**
+    - Mock adapter to return failure; assert `reloadFromSource()` returns failure and key is unchanged
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 4`
+
+  - [ ]* 7.3 Write property test for `SecretManager` — Property 5: Fetched key passes through validator
+    - **Property 5: Fetched key passes through validator**
+    - **Validates: Requirements 3.3**
+    - Mock adapter to return an invalid key string; assert reload fails and key is unchanged
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 5`
+
+  - [ ]* 7.4 Write property test for `SecretManager` — Property 6: Caching prevents redundant external calls
+    - **Property 6: Caching prevents redundant external calls**
+    - **Validates: Requirements 3.5**
+    - After a successful reload, call `getSecretKey()` multiple times; assert adapter was called exactly once
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 6`
+
+- [x] 8. Implement the admin reload endpoint
+  - [x] 8.1 Create `src/app/api/admin/reload-secret/route.ts` with `POST(request: Request): Promise<Response>`
+    - Read `Authorization: Bearer <token>` header
+    - Compare against `process.env.ADMIN_RELOAD_TOKEN` using `crypto.timingSafeEqual` (Buffer comparison)
+    - Return HTTP 401 `{ error: "Unauthorized" }` if token is missing or mismatched — before any key fetch
+    - On auth success, call `secretManager.reloadFromSource()`
+    - Return HTTP 200 `{ message: "Key reloaded successfully", timestamp }` on success
+    - Return HTTP 500 `{ error: "Reload failed: <reason>", timestamp }` on failure
+    - Neither response body may contain the key value
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 7.1_
+
+  - [ ]* 8.2 Write property test for reload endpoint — Property 7: Unauthorized requests rejected
+    - **Property 7: Unauthorized requests rejected, key unchanged**
+    - **Validates: Requirements 4.2, 4.3**
+    - For any token that is not the correct `ADMIN_RELOAD_TOKEN`, assert HTTP 401 and key unchanged
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 7`
+
+  - [ ]* 8.3 Write property test for reload endpoint — Property 8: Response body never contains key
+    - **Property 8: Response body never contains the key value**
+    - **Validates: Requirements 4.5, 4.6, 1.5, 7.1, 8.2, 8.3**
+    - For both success and failure outcomes, assert response body does not contain the current key as a substring
+    - Comment: `// Feature: dynamic-secret-key-reload, Property 8`
+
+  - [ ]* 8.4 Write adversarial unit tests for the reload endpoint
+    - Test: missing `Authorization` header → HTTP 401, no reload triggered
+    - Test: wrong token → HTTP 401, no reload triggered
+    - Test: malformed key from source → HTTP 500, `inMemoryKey` unchanged
+    - _Requirements: 4.3, 9.3, 9.4_
+
+- [x] 9. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 10. Wire `SecretManager` into existing signing flows
+  - [x] 10.1 Identify all call sites that read `process.env.STELLAR_SECRET_KEY` directly
+    - Search the codebase for `process.env.STELLAR_SECRET_KEY` references outside `secretManager.ts`
+    - _Requirements: 6.1, 6.3_
+
+  - [x] 10.2 Replace each call site with `import { getSecretKey } from '@/lib/secretManager'`
+    - Ensure the call pattern (sync vs. async) matches what the caller expects per Requirement 6.2
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ]* 10.3 Write integration tests for backward compatibility
+    - Test that existing signing/drip-execution code returns correct results after migration
+    - Test that a key updated mid-operation causes all subsequent operations to use the new key
+    - _Requirements: 6.1, 6.2, 9.2_
+
+  - [ ]* 10.4 Write concurrency integration test
+    - Simulate simultaneous reload and signing operations; assert no race conditions or partial state
+    - _Requirements: 5.2, 9.5_
+
+- [x] 11. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation at logical boundaries
+- Property tests validate universal correctness invariants; unit tests validate specific examples and edge cases
+- The `@stellar/stellar-sdk` package must be available — add it if not already installed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "stellarflow-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.1036.0",
+        "@stellar/stellar-sdk": "^15.0.1",
         "lucide-react": "^1.6.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -22,6 +24,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "fast-check": "^4.7.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -37,6 +40,667 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1036.0.tgz",
+      "integrity": "sha512-4Q0Rqh1CrNfwmAOrQF9FiuU2QmV51cTSa+rJJNan7/KzYUUlUFmavuWpKH+S3preT8iaTlCT0JyCqO46kg24RA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1182,6 +1846,45 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1236,6 +1939,624 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
+      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@stellar/js-xdr": "^4.0.0",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-15.0.1.tgz",
+      "integrity": "sha512-iZjWKXtfohsPh+CX9wRyQNIlXLeA9VyuQB6UMC7AFBD9XnR92eOjnlfeONzk/Bsrkk6+UPlpzSy2MuF+ydHP1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^15.0.0",
+        "axios": "1.14.0",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.3",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.11"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2396,11 +3717,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -2420,6 +3746,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2450,6 +3787,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -2461,6 +3827,21 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2521,11 +3902,34 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2544,7 +3948,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2558,7 +3961,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2643,6 +4045,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2770,7 +4193,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -2802,6 +4224,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2829,7 +4260,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2941,7 +4371,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2951,7 +4380,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2990,7 +4418,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3003,7 +4430,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3501,6 +4927,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3552,6 +5010,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3560,6 +5054,15 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3626,11 +5129,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -3642,11 +5164,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3707,7 +5244,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3732,7 +5268,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3820,7 +5355,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3863,7 +5397,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -3892,7 +5425,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3905,7 +5437,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3921,7 +5452,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3946,6 +5476,26 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3983,6 +5533,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4097,7 +5653,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4288,6 +5843,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-set": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
@@ -4356,7 +5923,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -4418,7 +5984,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4913,7 +6478,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4941,6 +6505,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5335,6 +6920,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5375,7 +6975,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5432,6 +7031,15 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5441,6 +7049,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5462,6 +7087,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",
@@ -5642,6 +7276,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5697,7 +7351,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -5740,6 +7393,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sharp": {
@@ -6065,6 +7738,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -6184,6 +7869,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6196,6 +7895,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -6259,7 +7964,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6474,6 +8178,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6561,7 +8271,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.1036.0",
+    "@stellar/stellar-sdk": "^15.0.1",
     "lucide-react": "^1.6.0",
     "next": "16.1.6",
     "react": "19.2.3",
@@ -23,6 +25,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "fast-check": "^4.7.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/src/app/api/admin/reload-secret/route.ts
+++ b/src/app/api/admin/reload-secret/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import * as secretManager from '@/lib/secretManager';
+import { logReloadEvent } from '@/lib/auditLogger';
+
+/**
+ * POST /admin/reload-secret
+ *
+ * Verifies the admin bearer token using timing-safe comparison, then triggers
+ * a hot reload of the Stellar secret key from the configured key source.
+ *
+ * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 7.1
+ */
+export async function POST(request: Request): Promise<Response> {
+  // ── Auth verification (Requirements 4.2, 4.3) ────────────────────────────
+  const authHeader = request.headers.get('Authorization');
+  const expectedToken = process.env.ADMIN_RELOAD_TOKEN ?? '';
+
+  // Extract bearer token from header
+  const bearerPrefix = 'Bearer ';
+  const providedToken =
+    authHeader && authHeader.startsWith(bearerPrefix)
+      ? authHeader.slice(bearerPrefix.length)
+      : null;
+
+  // Reject immediately if token is missing or if the expected token is not configured
+  if (!providedToken || expectedToken.length === 0) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Timing-safe comparison to prevent token enumeration attacks
+  const providedBuf = Buffer.from(providedToken);
+  const expectedBuf = Buffer.from(expectedToken);
+
+  // Buffers must be the same length for timingSafeEqual; length mismatch → reject
+  const tokensMatch =
+    providedBuf.length === expectedBuf.length &&
+    crypto.timingSafeEqual(providedBuf, expectedBuf);
+
+  if (!tokensMatch) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // ── Admin identity (use a masked token prefix as identity) ───────────────
+  const adminIdentity =
+    providedToken.length > 4
+      ? `${providedToken.slice(0, 4)}****`
+      : 'admin';
+
+  // ── Trigger reload (Requirements 4.4, 4.5, 4.6) ─────────────────────────
+  const timestamp = new Date().toISOString();
+  const result = await secretManager.reloadFromSource();
+
+  if (result.success) {
+    logReloadEvent({
+      timestamp,
+      adminIdentity,
+      outcome: 'success',
+    });
+
+    return NextResponse.json(
+      { message: 'Key reloaded successfully', timestamp },
+      { status: 200 }
+    );
+  } else {
+    const reason = result.reason;
+
+    logReloadEvent({
+      timestamp,
+      adminIdentity,
+      outcome: 'failure',
+      failureReason: reason,
+    });
+
+    return NextResponse.json(
+      { error: `Reload failed: ${reason}`, timestamp },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/adapters/awsAdapter.ts
+++ b/src/lib/adapters/awsAdapter.ts
@@ -1,0 +1,82 @@
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type FetchResult =
+  | { success: true; key: string }
+  | { success: false; error: string };
+
+// ── Client (lazy singleton) ───────────────────────────────────────────────────
+
+let client: SecretsManagerClient | null = null;
+
+function getClient(): SecretsManagerClient {
+  if (!client) {
+    client = new SecretsManagerClient({});
+  }
+  return client;
+}
+
+// ── fetchKey ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the Stellar secret key from AWS Secrets Manager.
+ *
+ * - Reads the ARN from `process.env.AWS_SECRET_ARN`.
+ * - Handles both plain-string secrets and JSON objects with a
+ *   `STELLAR_SECRET_KEY` field.
+ * - Never throws to callers — all errors are returned as structured failures.
+ * - Never logs the fetched key value (Requirements 7.1, 7.2).
+ *
+ * Requirements: 3.1, 7.1, 7.2
+ */
+export async function fetchKey(): Promise<FetchResult> {
+  const arn = process.env.AWS_SECRET_ARN;
+
+  if (!arn || arn.trim() === '') {
+    return { success: false, error: 'AWS_SECRET_ARN environment variable is not set' };
+  }
+
+  try {
+    const command = new GetSecretValueCommand({ SecretId: arn });
+    const response = await getClient().send(command);
+
+    const raw = response.SecretString;
+
+    if (!raw) {
+      return { success: false, error: 'AWS Secrets Manager returned an empty secret value' };
+    }
+
+    // Attempt to parse as JSON; fall back to treating the value as a plain string
+    let key: string;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'STELLAR_SECRET_KEY' in parsed &&
+        typeof (parsed as Record<string, unknown>).STELLAR_SECRET_KEY === 'string'
+      ) {
+        key = (parsed as Record<string, string>).STELLAR_SECRET_KEY;
+      } else {
+        // JSON but no expected field — treat the whole string as the key
+        key = raw;
+      }
+    } catch {
+      // Not JSON — use the raw string directly
+      key = raw;
+    }
+
+    if (!key || key.trim() === '') {
+      return { success: false, error: 'Resolved secret key is empty' };
+    }
+
+    return { success: true, key };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, error: `AWS Secrets Manager fetch failed: ${message}` };
+  }
+}

--- a/src/lib/adapters/fileAdapter.ts
+++ b/src/lib/adapters/fileAdapter.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'fs/promises';
+import { createDecipheriv } from 'crypto';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type FetchResult =
+  | { success: true; key: string }
+  | { success: false; error: string };
+
+// ── fetchKey ──────────────────────────────────────────────────────────────────
+
+/**
+ * Reads and decrypts the Stellar secret key from a local encrypted file.
+ *
+ * Expected environment variables:
+ *   - `SECRET_FILE_PATH`    — path to the encrypted file
+ *   - `FILE_ENCRYPTION_KEY` — hex-encoded 32-byte AES-256-GCM key
+ *
+ * File format (UTF-8 text):
+ *   <iv_hex>:<authTag_hex>:<ciphertext_hex>
+ *
+ * Never throws to callers — all errors are returned as structured failures.
+ * Never logs the decrypted key value (Requirement 7.1).
+ *
+ * Requirements: 3.2, 7.1
+ */
+export async function fetchKey(): Promise<FetchResult> {
+  const filePath = process.env.SECRET_FILE_PATH;
+  const encKeyHex = process.env.FILE_ENCRYPTION_KEY;
+
+  if (!filePath || filePath.trim() === '') {
+    return { success: false, error: 'SECRET_FILE_PATH environment variable is not set' };
+  }
+
+  if (!encKeyHex || encKeyHex.trim() === '') {
+    return { success: false, error: 'FILE_ENCRYPTION_KEY environment variable is not set' };
+  }
+
+  // Read the encrypted file
+  let fileContents: string;
+  try {
+    fileContents = await readFile(filePath, 'utf-8');
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isNotFound =
+      err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    return {
+      success: false,
+      error: isNotFound
+        ? `Secret file not found at path: ${filePath}`
+        : `Failed to read secret file: ${message}`,
+    };
+  }
+
+  // Parse the file format: <iv_hex>:<authTag_hex>:<ciphertext_hex>
+  const parts = fileContents.trim().split(':');
+  if (parts.length !== 3) {
+    return {
+      success: false,
+      error: 'Secret file has invalid format; expected <iv_hex>:<authTag_hex>:<ciphertext_hex>',
+    };
+  }
+
+  const [ivHex, authTagHex, ciphertextHex] = parts;
+
+  // Decrypt using AES-256-GCM
+  try {
+    const encKey = Buffer.from(encKeyHex, 'hex');
+    if (encKey.length !== 32) {
+      return {
+        success: false,
+        error: `FILE_ENCRYPTION_KEY must be a hex-encoded 32-byte key (got ${encKey.length} bytes)`,
+      };
+    }
+
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const ciphertext = Buffer.from(ciphertextHex, 'hex');
+
+    const decipher = createDecipheriv('aes-256-gcm', encKey, iv);
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    const key = decrypted.toString('utf-8').trim();
+
+    if (!key) {
+      return { success: false, error: 'Decrypted secret key is empty' };
+    }
+
+    return { success: true, key };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, error: `Decryption failed: ${message}` };
+  }
+}

--- a/src/lib/auditLogger.ts
+++ b/src/lib/auditLogger.ts
@@ -1,0 +1,38 @@
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface AuditEvent {
+  timestamp: string;       // ISO 8601
+  adminIdentity: string;
+  outcome: 'success' | 'failure';
+  failureReason?: string;
+}
+
+// ── logReloadEvent ────────────────────────────────────────────────────────────
+
+/**
+ * Emits a structured JSON audit log entry for a secret-key reload event.
+ *
+ * The entry includes a fixed `event` discriminator plus all fields from the
+ * supplied AuditEvent. An optional `currentKey` may be passed so that any
+ * accidental occurrence of the key value is redacted before writing.
+ *
+ * Requirements: 8.1, 8.2, 8.3
+ */
+export function logReloadEvent(event: AuditEvent, currentKey?: string): void {
+  const entry = {
+    event: 'secret-key-reload',
+    timestamp: event.timestamp,
+    adminIdentity: event.adminIdentity,
+    outcome: event.outcome,
+    ...(event.failureReason !== undefined && { failureReason: event.failureReason }),
+  };
+
+  let serialized = JSON.stringify(entry);
+
+  // Best-effort redaction: replace any occurrence of the current key (Req 8.2)
+  if (currentKey && currentKey.length > 0) {
+    serialized = serialized.split(currentKey).join('[REDACTED]');
+  }
+
+  console.log(serialized);
+}

--- a/src/lib/mutex.ts
+++ b/src/lib/mutex.ts
@@ -1,0 +1,31 @@
+/**
+ * AsyncMutex — promise-chain-based mutual exclusion for async operations.
+ *
+ * Usage:
+ *   const release = await mutex.acquire();
+ *   try {
+ *     // critical section
+ *   } finally {
+ *     release();
+ *   }
+ */
+export class AsyncMutex {
+  private _queue: Promise<void> = Promise.resolve();
+
+  /**
+   * Acquire the mutex. Returns a promise that resolves to a release function.
+   * The caller MUST invoke the release function in a `finally` block to avoid deadlocks.
+   */
+  acquire(): Promise<() => void> {
+    let release!: () => void;
+
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const entry = this._queue.then(() => release);
+    this._queue = this._queue.then(() => next);
+
+    return entry;
+  }
+}

--- a/src/lib/secretManager.ts
+++ b/src/lib/secretManager.ts
@@ -1,0 +1,192 @@
+import { AsyncMutex } from './mutex';
+import { validate } from './validator';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type UpdateResult =
+  | { success: true }
+  | { success: false; reason: string };
+
+export type ReloadResult =
+  | { success: true }
+  | { success: false; reason: string };
+
+// ── Custom error ─────────────────────────────────────────────────────────────
+
+export class SecretManagerInitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecretManagerInitError';
+  }
+}
+
+// ── Module-level state (Task 3.1) ─────────────────────────────────────────────
+
+const mutex = new AsyncMutex();
+
+// Initialize inMemoryKey from the environment variable on module load.
+// Throws SecretManagerInitError if the env var is absent, empty, or invalid.
+function initKey(): string {
+  const raw = process.env.STELLAR_SECRET_KEY;
+
+  if (!raw || raw.trim() === '') {
+    throw new SecretManagerInitError(
+      'STELLAR_SECRET_KEY environment variable is absent or empty. ' +
+        'The server cannot start without a valid Stellar secret key.'
+    );
+  }
+
+  const result = validate(raw);
+  if (!result.valid) {
+    throw new SecretManagerInitError(
+      `STELLAR_SECRET_KEY failed validation at startup: ${result.reason}`
+    );
+  }
+
+  return raw;
+}
+
+let inMemoryKey: string = initKey();
+
+// ── getSecretKey (Task 3.2) ───────────────────────────────────────────────────
+
+/**
+ * Returns the current in-memory Stellar secret key synchronously.
+ * No locking is required — JS reads are atomic and the key reference is
+ * replaced atomically on update (Requirements 1.1, 6.1, 6.2).
+ */
+export function getSecretKey(): string {
+  return inMemoryKey;
+}
+
+// ── updateSecretKey (Task 3.3) ────────────────────────────────────────────────
+
+/**
+ * Validates and atomically replaces the in-memory secret key.
+ *
+ * - Validates the candidate before acquiring the mutex (fail-fast).
+ * - If the candidate equals the current key, returns success immediately (no-op).
+ * - Acquires the mutex, overwrites inMemoryKey, releases in finally.
+ * - Emits an audit log entry after a successful update.
+ *
+ * Requirements: 1.2, 2.2, 2.3, 5.1, 5.3, 7.4
+ */
+export async function updateSecretKey(newKey: string): Promise<UpdateResult> {
+  // Validate before acquiring the lock (fail-fast, no contention on bad input)
+  const validation = validate(newKey);
+  if (!validation.valid) {
+    return { success: false, reason: `Invalid key format: ${validation.reason}` };
+  }
+
+  // No-op: candidate is identical to the current key (Requirement 2.3)
+  if (newKey === inMemoryKey) {
+    return { success: true };
+  }
+
+  // Acquire mutex → overwrite → release (Requirements 5.1, 7.4)
+  const release = await mutex.acquire();
+  try {
+    inMemoryKey = newKey; // atomic reference swap (Requirement 5.3)
+  } finally {
+    release();
+  }
+
+  // Emit audit log after successful update (Requirement 8.1)
+  // Dynamic import so that auditLogger.ts can be created independently (Task 4)
+  try {
+    const { logReloadEvent } = await import('./auditLogger');
+    logReloadEvent({
+      timestamp: new Date().toISOString(),
+      adminIdentity: 'system',
+      outcome: 'success',
+    });
+  } catch {
+    // auditLogger not yet available or failed — do not block the update
+  }
+
+  return { success: true };
+}
+
+// ── reloadFromSource (Task 7.1) ───────────────────────────────────────────────
+
+/**
+ * Fetches the latest key from the configured key source (AWS Secrets Manager
+ * if `AWS_SECRET_ARN` is set, otherwise the local encrypted file adapter),
+ * passes the result through the Validator via `updateSecretKey`, and atomically
+ * replaces the in-memory key on success.
+ *
+ * On any failure (fetch error or validation error) the existing `inMemoryKey`
+ * is retained unchanged and a structured error is returned.
+ *
+ * Emits an audit log entry for both success and failure outcomes.
+ * The `adminIdentity` for system-triggered reloads is 'system'.
+ *
+ * Requirements: 3.1, 3.2, 3.3, 3.4, 3.5
+ */
+export async function reloadFromSource(): Promise<ReloadResult> {
+  const { AWS_SECRET_ARN } = process.env;
+
+  // ── Step 1: Fetch raw key from the appropriate adapter ──────────────────────
+  let rawKey: string;
+
+  if (AWS_SECRET_ARN) {
+    const { fetchKey } = await import('./adapters/awsAdapter');
+    const result = await fetchKey();
+    if (!result.success) {
+      await emitReloadAuditLog('failure', result.error);
+      return { success: false, reason: result.error };
+    }
+    rawKey = result.key;
+  } else {
+    const { fetchKey } = await import('./adapters/fileAdapter');
+    const result = await fetchKey();
+    if (!result.success) {
+      await emitReloadAuditLog('failure', result.error);
+      return { success: false, reason: result.error };
+    }
+    rawKey = result.key;
+  }
+
+  // ── Step 2: Validate and apply via updateSecretKey ──────────────────────────
+  // updateSecretKey runs the Validator before acquiring the mutex (Req 3.3).
+  // On validation failure it returns a structured error without touching inMemoryKey (Req 3.4).
+  const updateResult = await updateSecretKey(rawKey);
+  if (!updateResult.success) {
+    await emitReloadAuditLog('failure', updateResult.reason);
+    return { success: false, reason: updateResult.reason };
+  }
+
+  // ── Step 3: Emit success audit log ─────────────────────────────────────────
+  // updateSecretKey already emits a log entry; we emit an additional one here
+  // scoped to the reload operation so operators can distinguish reload-triggered
+  // updates from direct updateSecretKey calls.
+  await emitReloadAuditLog('success');
+
+  return { success: true };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Emits a structured audit log entry for a reloadFromSource event.
+ * Silently swallows errors so that a logging failure never blocks the caller.
+ */
+async function emitReloadAuditLog(
+  outcome: 'success' | 'failure',
+  failureReason?: string
+): Promise<void> {
+  try {
+    const { logReloadEvent } = await import('./auditLogger');
+    logReloadEvent(
+      {
+        timestamp: new Date().toISOString(),
+        adminIdentity: 'system',
+        outcome,
+        ...(failureReason !== undefined && { failureReason }),
+      },
+      inMemoryKey
+    );
+  } catch {
+    // Logging failure must never block or corrupt the reload result
+  }
+}

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -1,0 +1,25 @@
+import { Keypair } from '@stellar/stellar-sdk';
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+/**
+ * Validates that a candidate string is a well-formed Stellar secret key.
+ *
+ * Uses Keypair.fromSecret() to verify the key starts with 'S' and passes
+ * the SDK's internal checksum. The reason field never echoes the candidate
+ * value (Requirement 7.1).
+ */
+export function validate(candidate: string): ValidationResult {
+  if (!candidate.startsWith('S')) {
+    return { valid: false, reason: "Key does not begin with 'S'" };
+  }
+
+  try {
+    Keypair.fromSecret(candidate);
+    return { valid: true };
+  } catch {
+    return { valid: false, reason: 'Key failed Stellar SDK validation (invalid format or checksum)' };
+  }
+}


### PR DESCRIPTION
Closes #152

Adds runtime secret key rotation without restarting the server.

What's changed

SecretManager — central module for getting/updating the Stellar secret key in memory
Validator — validates key format via Stellar SDK before any update is applied
AsyncMutex — prevents race conditions during concurrent key updates
AWS Secrets Manager adapter + local AES-256-GCM encrypted file fallback
POST /admin/reload-secret — bearer-token-protected endpoint to trigger a hot reload
AuditLogger — structured JSON logging for all reload events (no key values logged)
How to trigger a reload

curl -X POST https://<host>/admin/reload-secret \
  -H "Authorization: Bearer <ADMIN_RELOAD_TOKEN>"
Env vars required

Var	Purpose
STELLAR_SECRET_KEY	Initial key on startup
ADMIN_RELOAD_TOKEN	Auth token for the reload endpoint
AWS_SECRET_ARN	(optional) Use AWS Secrets Manager as key source
SECRET_FILE_PATH + FILE_ENCRYPTION_KEY	(optional) Use encrypted file fallback