### PR TITLE
feat: prefetch admin settings route on settings icon hover (issue #59)

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,10 @@
+export default function AdminSettingsPage() {
+  return (
+    <main className="min-h-screen bg-zinc-950 text-white flex items-center justify-center">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold text-[#99DC1B]">Admin Settings</h1>
+        <p className="text-zinc-400 text-sm">Configure system parameters here.</p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -1,11 +1,14 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 import { FaWallet, FaBell, FaCircleUser, FaRightFromBracket } from 'react-icons/fa6';
 
 const Nav = () => {
   const hasAnomaly = true; // replace with real signal condition (e.g., Coinbase GHS Offline)
+  const router = useRouter();
 
   const handleConnectWallet = () => {
     alert('Connect Wallet clicked! (Add your Web3 logic here)');
@@ -62,13 +65,15 @@ const Nav = () => {
             )}
           </button>
 
-          <button
-            aria-label="User profile"
+          <Link
+            href="/admin/settings"
+            prefetch={false}
+            onMouseEnter={() => router.prefetch('/admin/settings')}
+            aria-label="Admin settings"
             className="p-2 rounded-xl hover:bg-zinc-800 transition-colors"
-            onClick={() => alert('User settings (implement)')}
           >
             <FaCircleUser className="w-6 h-6 text-slate-200" />
-          </button>
+          </Link>
 
           <button
             aria-label="Sign out"


### PR DESCRIPTION
What changed

Implemented strategic pre-fetching of the Admin Settings route when the user hovers over the settings icon in the nav.

New file: 
page.tsx

Minimal admin settings page at /admin/settings for the prefetch target
Modified file: 
nav.jsx

Replaced the profile <button> with <Link href="/admin/settings" prefetch={false}>
Added onMouseEnter handler that calls router.prefetch('/admin/settings') — this triggers Next.js to load the route's JS chunk in the background the moment the user hovers, so navigation feels instant when they click
prefetch={false} ensures the default eager prefetch is disabled; prefetching only happens on hover as intended
Behaviour

No prefetch on page load — zero wasted bandwidth for users who never visit admin settings
Hover over the settings icon → route chunk silently pre-loaded
Click → near-instant navigation since the code is already in the browser cache

closes #59 