### PR TITLE
feat: add RateSparklineCard component and integrate into page

### DIFF
--- a/src/app/components/RateSparklineCard.tsx
+++ b/src/app/components/RateSparklineCard.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React, { useMemo } from "react";
+
+interface RateSparklineCardProps {
+  currency: string;
+  rate: number;
+  trend: number;
+  sparklineData: number[];
+}
+
+const MiniSparkline = React.memo(function MiniSparkline({
+  data,
+}: {
+  data: number[];
+}) {
+  const points = useMemo(() => {
+    const width = 120;
+    const height = 32;
+
+    if (data.length < 2) {
+      return "";
+    }
+
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    const range = max - min || 1;
+
+    return data
+      .map((value, index) => {
+        const x = (index / (data.length - 1)) * width;
+        const y = height - ((value - min) / range) * height;
+        return `${x},${y}`;
+      })
+      .join(" ");
+  }, [data]);
+
+  return (
+    <svg viewBox="0 0 120 32" className="h-8 w-full overflow-visible" role="img" aria-label="Sparkline chart">
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        points={points}
+      />
+    </svg>
+  );
+});
+
+const RateSparklineCard: React.FC<RateSparklineCardProps> = ({
+  currency,
+  rate,
+  trend,
+  sparklineData,
+}) => {
+  const isPositive = trend >= 0;
+
+  const formattedRate = useMemo(
+    () => `${currency} ${rate.toFixed(2)}`,
+    [currency, rate]
+  );
+
+  const trendLabel = useMemo(
+    () => `${isPositive ? "▲" : "▼"} ${Math.abs(trend).toFixed(2)}%`,
+    [isPositive, trend]
+  );
+
+  const trendClasses = useMemo(
+    () =>
+      isPositive
+        ? "bg-emerald-500/10 text-emerald-300 border border-emerald-500/20"
+        : "bg-rose-500/10 text-rose-300 border border-rose-500/20",
+    [isPositive]
+  );
+
+  const sparklineClasses = useMemo(
+    () => (isPositive ? "text-emerald-400" : "text-rose-400"),
+    [isPositive]
+  );
+
+  return (
+    <div className="rounded-3xl border border-[#1B2A3B] bg-[#08111E] p-5 shadow-lg shadow-black/20 transition duration-300 hover:border-[#39FF14]/40">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-gray-500">{currency}</p>
+          <p className="mt-2 text-2xl font-black text-white tracking-tight">{formattedRate}</p>
+        </div>
+        <span className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-semibold ${trendClasses}`}>
+          {trendLabel}
+        </span>
+      </div>
+
+      <div className={`mt-4 ${sparklineClasses}`}>
+        <MiniSparkline data={sparklineData} />
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(RateSparklineCard);

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -5,6 +5,35 @@ import FloatingSidebar from "./components/FloatingSidebar";
 import SystemStats from "./components/SystemStats";
 import ModularStatsCard from "./components/ModularStatsCard";
 import PriceFeedCard from "./components/PriceFeedCard";
+import RateSparklineCard from "./components/RateSparklineCard";
+import RelayerStatusTable from "./components/RelayerStatusTable";
+
+const mockRelayers = [
+  { id: "r1", name: "Abuja Relayer", status: "Online", latency: 34 },
+  { id: "r2", name: "Lagos Relayer", status: "Syncing", latency: 72 },
+  { id: "r3", name: "Cape Town Relayer", status: "Online", latency: 48 },
+];
+
+const rateCards = [
+  {
+    currency: "NGN",
+    rate: 13.42,
+    trend: 1.8,
+    sparklineData: [12.9, 13.1, 13.0, 13.3, 13.5, 13.4, 13.42],
+  },
+  {
+    currency: "KES",
+    rate: 0.30,
+    trend: -0.6,
+    sparklineData: [0.31, 0.305, 0.302, 0.300, 0.299, 0.301, 0.300],
+  },
+  {
+    currency: "GHS",
+    rate: 0.11,
+    trend: 0.9,
+    sparklineData: [0.108, 0.109, 0.110, 0.111, 0.110, 0.109, 0.110],
+  },
+];
 
 const LoadingChartState = () => {
   return (
@@ -56,6 +85,13 @@ const page = () => {
             <ModularStatsCard label="Oracle Accuracy" value={99.98} trend={0.01} unit="%" />
           </section>
 
+          {/* Local FX rates with memoized sparklines */}
+          <section className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            {rateCards.map((card) => (
+              <RateSparklineCard key={card.currency} {...card} />
+            ))}
+          </section>
+
           {/* Dynamic Price Feed — NGN/XLM */}
           <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <PriceFeedCard refreshInterval={30000} />
@@ -63,7 +99,7 @@ const page = () => {
           
           {/* Relayer Status Table */}
           <section className="space-y-4">
-            <h2 className="text-xl font-semibold text-white uppercase tracking-wider text-sm mb-4">Relayer Network Status</h2>
+            <h2 className="text-xl font-semibold text-white uppercase tracking-wider mb-4">Relayer Network Status</h2>
             <RelayerStatusTable relayers={mockRelayers} />
           </section>
 


### PR DESCRIPTION
Closes #51 

## Summary

This PR adds memoized mini-sparkline UI cards for the NGN, KES, and GHS currency rates in the StellarFlow frontend. The update improves rendering performance by ensuring Sparkline subcomponents only re-render when their underlying rate data changes.

## What Changed

- Added `src/app/components/RateSparklineCard.tsx`:
  - Introduces a reusable rate card component with a mini sparkline chart.
  - Uses `React.memo` for component memoization.
  - Uses `useMemo` to compute sparkline points and formatted display values.

- Updated `src/app/page.jsx`:
  - Added a new local FX rates section rendering NGN/KES/GHS cards.
  - Imported `RateSparklineCard` and `RelayerStatusTable`.
  - Added sample mock data for relayer status and rate cards.

## Why This Matters

- Prevents unnecessary re-renders of chart elements when unrelated state updates occur.
- Improves perceived performance in the dashboard's FX rate section.
- Establishes a reusable pattern for future memoized rate chart components.

## Files Changed

- `src/app/components/RateSparklineCard.tsx`
- `src/app/page.jsx`
- `PULL_REQUEST.md`

## Testing

- Verified that the new component renders successfully in the page layout.
- Confirmed the page imports are correct and no missing component references exist.
- Note: local lint command failed because `eslint` is not installed globally in this environment. The source code was validated for structure and imports.

## Notes

- This PR does not change backend API behavior or the existing `PriceFeedCard` logic.
- The new FX cards currently use static mock data for NGN, KES, and GHS rates.
