### PR TITLE
feat: Add service worker for offline dashboard shell

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,30 @@
 import type { NextConfig } from "next";
+import withPWA from "next-pwa";
 
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: false,
 };
 
-export default nextConfig;
+const pwaConfig = withPWA({
+  dest: "public",
+  register: true,
+  skipWaiting: true,
+  disable: process.env.NODE_ENV === "development",
+  runtimeCaching: [
+    {
+      urlPattern: /^https?.*/,
+      handler: "NetworkFirst",
+      options: {
+        cacheName: "offlineCache",
+        expiration: {
+          maxEntries: 200,
+          maxAgeSeconds: 24 * 60 * 60, // 24 hours
+        },
+        networkTimeoutSeconds: 10,
+      },
+    },
+  ],
+});
+
+export default pwaConfig(nextConfig);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "lucide-react": "^1.6.0",
     "next": "16.1.6",
+    "next-pwa": "^5.6.0",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "StellarFlow Dashboard",
+  "short_name": "StellarFlow",
+  "description": "StellarFlow Network Dashboard",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
- Add next-pwa dependency for PWA support
- Configure next.config.ts with PWA settings for offline caching
- Add manifest.json for PWA capabilities

Implements #58 Service Worker for Offline Dashboard Shell

closes #58