### PR TITLE
feat: add environment configuration with build-time validation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import "@/config/env";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,16 @@
+// src/config/env.ts
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `[StellarFlow] Missing required environment variable: "${name}"\n` +
+        `Please add it to your .env.local file.`
+    );
+  }
+  return value;
+}
+
+export const env = {
+  NEXT_PUBLIC_API_URL: requireEnv("NEXT_PUBLIC_API_URL"),
+} as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["node"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Changes
- Created `src/config/env.ts` to export and validate environment variables
- App throws a clear error at build time if `NEXT_PUBLIC_API_URL` is missing
- Imported config in `layout.tsx` to ensure validation runs on build
Closes #28 