### PR TITLE
Perf | Zero-Layout Shift Skeleton Screens

### DIFF
--- a/src/app/components/FloatingSidebar.tsx
+++ b/src/app/components/FloatingSidebar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import {
   LayoutDashboard,
   Database,
@@ -10,15 +12,17 @@ import {
 } from "lucide-react";
 
 const navItems = [
-  { icon: LayoutDashboard, label: "Dashboard", href: "#" },
-  { icon: Database, label: "Data", href: "#" },
-  { icon: LineChart, label: "Analytics", href: "#" },
-  { icon: Globe, label: "Governance", href: "#" },
-  { icon: Settings, label: "Settings", href: "#" },
+  { icon: LayoutDashboard, label: "Dashboard", href: "/" },
+  { icon: Database, label: "Contracts", href: "/contracts" },
+  { icon: LineChart, label: "Analytics", href: "/analytics" },
+  { icon: Globe, label: "Governance", href: "/governance" },
+  { icon: Settings, label: "Settings", href: "/settings" },
 ];
 
 export default function FloatingSidebar() {
-  const [active, setActive] = useState("Data");
+  const pathname = usePathname();
+  const router = useRouter();
+  const [active, setActive] = useState(pathname ?? "Dashboard");
   const [hovered, setHovered] = useState<string | null>(null);
 
   return (
@@ -34,7 +38,7 @@ export default function FloatingSidebar() {
       }}
     >
       {navItems.map(({ icon: Icon, label, href }) => {
-        const isActive = active === label;
+        const isActive = pathname === href || active === href;
         const isHovered = hovered === label;
 
         return (
@@ -52,13 +56,21 @@ export default function FloatingSidebar() {
               />
             )}
 
-            <a
+            <Link
               href={href}
-              onClick={(e) => {
-                e.preventDefault();
-                setActive(label);
+              prefetch={href === "/contracts" ? false : undefined}
+              onClick={() => setActive(href)}
+              onFocus={() => {
+                if (href === "/contracts") {
+                  router.prefetch("/contracts");
+                }
               }}
               onMouseEnter={() => setHovered(label)}
+              onMouseOver={() => {
+                if (href === "/contracts") {
+                  router.prefetch("/contracts");
+                }
+              }}
               onMouseLeave={() => setHovered(null)}
               className="relative flex items-center justify-center rounded-xl transition-all duration-200"
               style={{
@@ -79,7 +91,7 @@ export default function FloatingSidebar() {
               aria-label={label}
             >
               <Icon size={20} strokeWidth={isActive ? 2.2 : 1.8} />
-            </a>
+            </Link>
 
             {/* Tooltip */}
             {isHovered && (

--- a/src/app/components/ModularStatsCard.tsx
+++ b/src/app/components/ModularStatsCard.tsx
@@ -25,7 +25,7 @@ const ModularStatsCard: React.FC<ModularStatsCardProps> = ({
   const isPositive = trend !== undefined && trend >= 0;
 
   return (
-    <div className="bg-[#0A121E] border border-[#1B2A3B] rounded-xl p-6 shadow-lg hover:border-[#39FF14]/50 transition-all duration-300 group">
+    <div className="relative h-full bg-[#0A121E] border border-[#1B2A3B] rounded-xl p-6 shadow-lg hover:border-[#39FF14]/50 transition-all duration-300 group">
       <div className="flex flex-col gap-2">
         {/* Label */}
         <h3 className="text-gray-400 text-xs font-semibold uppercase tracking-wider group-hover:text-[#39FF14] transition-colors">

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -187,7 +187,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
     <div
       className={`
         relative overflow-hidden
-        bg-[#0A121E] border border-[#1B2A3B] rounded-2xl p-6
+        h-full bg-[#0A121E] border border-[#1B2A3B] rounded-2xl p-6
         shadow-lg hover:border-[#39FF14]/40 transition-all duration-300 group
         ${!loading && !error ? trendGlow : ""}
       `}

--- a/src/app/components/RateSparklineCard.tsx
+++ b/src/app/components/RateSparklineCard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import React, { useMemo } from "react";
+import { Shimmer } from "@/components/skeletons/Shimmer";
 
 interface RateSparklineCardProps {
   currency: string;
   rate: number;
   trend: number;
-  sparklineData: number[];
+  sparklineData?: number[];
+  loading?: boolean;
 }
 
 const MiniSparkline = React.memo(function MiniSparkline({
@@ -53,7 +55,8 @@ const RateSparklineCard: React.FC<RateSparklineCardProps> = ({
   currency,
   rate,
   trend,
-  sparklineData,
+  sparklineData = [],
+  loading = false,
 }) => {
   const isPositive = trend >= 0;
 
@@ -80,8 +83,29 @@ const RateSparklineCard: React.FC<RateSparklineCardProps> = ({
     [isPositive]
   );
 
+  if (loading) {
+    return (
+      <div className="aspect-[16/10] rounded-3xl border border-[#1B2A3B] bg-[#08111E] p-5 shadow-lg shadow-black/20">
+        <div className="flex h-full flex-col justify-between">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <Shimmer className="h-3 w-14 rounded-md" />
+              <Shimmer className="h-8 w-32 rounded-md" />
+            </div>
+            <Shimmer className="h-6 w-16 rounded-full" />
+          </div>
+
+          <div className="space-y-3">
+            <Shimmer className="h-[1px] w-full" />
+            <Shimmer className="h-8 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-3xl border border-[#1B2A3B] bg-[#08111E] p-5 shadow-lg shadow-black/20 transition duration-300 hover:border-[#39FF14]/40">
+    <div className="aspect-[16/10] rounded-3xl border border-[#1B2A3B] bg-[#08111E] p-5 shadow-lg shadow-black/20 transition duration-300 hover:border-[#39FF14]/40">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-[0.3em] text-gray-500">{currency}</p>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { Loader2 } from "lucide-react";
 import Nav from "./components/nav";
@@ -12,6 +12,7 @@ import RateSparklineCard from "./components/RateSparklineCard";
 import RelayerStatusTable from "./components/RelayerStatusTable";
 import WebSocketTest from "./components/test/WebSocketTest";
 import { Shimmer } from "@/components/skeletons/Shimmer";
+import { MapSkeleton } from "@/components/skeletons/MapSkeleton";
 
 const LiveNetworkMap = dynamic(() => import("@/app/components/Map"), {
   ssr: false,
@@ -34,9 +35,9 @@ const mockRelayers = [
 
 // Mock rate cards data
 const rateCards = [
-  { currency: "NGN", rate: 750.50, change: 2.3 },
-  { currency: "USD", rate: 0.12, change: -0.8 },
-  { currency: "EUR", rate: 0.13, change: 1.2 },
+  { currency: "NGN", rate: 750.5, trend: 2.3, sparklineData: [742, 744, 745, 748, 750, 749, 751] },
+  { currency: "USD", rate: 0.12, trend: -0.8, sparklineData: [0.13, 0.13, 0.125, 0.124, 0.123, 0.122, 0.12] },
+  { currency: "EUR", rate: 0.13, trend: 1.2, sparklineData: [0.124, 0.125, 0.126, 0.127, 0.128, 0.129, 0.13] },
 ];
 
 const LoadingChartState = () => {
@@ -44,6 +45,13 @@ const LoadingChartState = () => {
 };
 
 export default function DashboardPage() {
+  const [cardsReady, setCardsReady] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setCardsReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   return (
     <div className="min-h-screen bg-[#020817] text-white selection:bg-[#CBF34D]/30">
       <Nav />
@@ -57,22 +65,24 @@ export default function DashboardPage() {
 
           {/* Modular Stats Cards Section */}
           <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            <ModularStatsCard label="Network Throughput" value={1245670} trend={12.5} unit="TPS" />
-            <ModularStatsCard label="Total Value Locked" value={85432000} trend={-2.4} unit="USD" />
-            <ModularStatsCard label="Active Nodes" value={1240} trend={0.8} />
-            <ModularStatsCard label="Oracle Accuracy" value={99.98} trend={0.01} unit="%" />
+            <div className="aspect-[16/10]"><ModularStatsCard label="Network Throughput" value={1245670} trend={12.5} unit="TPS" /></div>
+            <div className="aspect-[16/10]"><ModularStatsCard label="Total Value Locked" value={85432000} trend={-2.4} unit="USD" /></div>
+            <div className="aspect-[16/10]"><ModularStatsCard label="Active Nodes" value={1240} trend={0.8} /></div>
+            <div className="aspect-[16/10]"><ModularStatsCard label="Oracle Accuracy" value={99.98} trend={0.01} unit="%" /></div>
           </section>
 
           {/* Local FX rates with memoized sparklines */}
           <section className="grid grid-cols-1 sm:grid-cols-3 gap-6">
             {rateCards.map((card) => (
-              <RateSparklineCard key={card.currency} {...card} />
+              <RateSparklineCard key={card.currency} {...card} loading={!cardsReady} />
             ))}
           </section>
 
           {/* Dynamic Price Feed — NGN/XLM */}
           <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            <PriceFeedCard refreshInterval={30000} />
+            <div className="sm:col-span-2 lg:col-span-1 aspect-[4/3] min-h-[320px]">
+              <PriceFeedCard refreshInterval={30000} />
+            </div>
           </section>
 
           {/* WebSocket Test Component */}


### PR DESCRIPTION
close #92 

Description
Updated the floating sidebar to use next/link with route-aware active state via usePathname and useRouter, and trigger router.prefetch('/contracts') on hover/focus to preload the Contracts module.
Added an exact-match skeleton mode and reserved geometry to RateSparklineCard (loading prop) that renders a shimmer chrome with aspect-[16/10] to match the real card dimensions.
Wrapped dashboard cards (metrics and price feed) in fixed aspect-ratio containers and made the inner card components fill available height (h-full / relative h-full) to reserve space before hydration.
Added a single-frame skeleton gate on the dashboard (requestAnimationFrame) and provided deterministic sparkline data for initial render to smooth the first paint.

Testing
Ran file-scoped linting with npx eslint src/app/components/FloatingSidebar.tsx src/app/components/RateSparklineCard.tsx src/app/components/PriceFeedCard.tsx src/app/components/ModularStatsCard.tsx src/app/page.jsx, which completed (only pre-existing warnings remain for unused socket helpers).
Ran project lint with npm run lint, which still fails due to unrelated repository-wide legacy lint issues (CommonJS require, any types, and other files outside this change).
Started the dev server with npm run dev and confirmed Next.js started successfully (dev server ready).


