### PR TITLE
add cleanup for WebSocket connection on component unmount

### DIFF
--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -172,6 +172,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current)
       }
+      if (wsRef.current) {
+        wsRef.current.close(1000, 'Component unmount')
+        wsRef.current = null
+      }
     }
   }, [])
 


### PR DESCRIPTION
fix: close WebSocket connection on component unmount
Ensure WebSocket connections are properly closed when components
unmount to prevent background bandwidth consumption from lingering
connections after navigating away from the dashboard.
- Close WebSocket with close() on component unmount
- Clear pending reconnect timeouts to prevent orphaned timers

Closes #105 