### PR TITLE
perf/feat: lucide tree-shaking and middleware admin session guard

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,11 @@ import type { NextConfig } from "next";
 import withPWA from "next-pwa";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: false,
   turbopack: {},
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
 };
 
 const pwaConfig = withPWA({

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
-import { FaWallet, FaBell, FaCircleUser, FaRightFromBracket } from 'react-icons/fa6';
+import { Wallet, Bell, CircleUser, LogOut } from 'lucide-react';
 import { useProgressBar } from './TopLoadingBar';
 
 const Nav = () => {
@@ -52,7 +52,7 @@ const Nav = () => {
                        text-sm sm:text-base transition-all duration-300 
                        hover:shadow-xl active:scale-95 whitespace-nowrap"
           >
-            <FaWallet className="w-5 h-5 transition-transform group-hover:rotate-12" />
+            <Wallet className="w-5 h-5 transition-transform group-hover:rotate-12" />
             <span>Connect <span className='max-md:hidden'>Wallet</span></span>
           </button>
 
@@ -61,7 +61,7 @@ const Nav = () => {
             className="relative p-2 rounded-xl hover:bg-zinc-800 transition-colors"
             onClick={() => alert('View current system anomalies (implement dashboard logic)')}
           >
-            <FaBell className="w-6 h-6 text-slate-200" />
+            <Bell className="w-6 h-6 text-slate-200" />
             {hasAnomaly && (
               <span className="absolute -top-1 -right-1 inline-flex h-3 w-3">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75" />
@@ -77,7 +77,7 @@ const Nav = () => {
             aria-label="Admin settings"
             className="p-2 rounded-xl hover:bg-zinc-800 transition-colors"
           >
-            <FaCircleUser className="w-6 h-6 text-slate-200" />
+            <CircleUser className="w-6 h-6 text-slate-200" />
           </Link>
 
           <button
@@ -85,7 +85,7 @@ const Nav = () => {
             className="p-2 rounded-xl hover:bg-zinc-800 transition-colors"
             onClick={() => alert('Sign out (implement)')}
           >
-            <FaRightFromBracket className="w-6 h-6 text-slate-200" />
+            <LogOut className="w-6 h-6 text-slate-200" />
           </button>
         </div>
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const ADMIN_COOKIE = 'sf_admin_session';
+const ADMIN_PATHS = ['/admin'];
+
+function isAdminPath(pathname: string): boolean {
+  return ADMIN_PATHS.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  if (!isAdminPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  const sessionToken = request.cookies.get(ADMIN_COOKIE)?.value;
+
+  if (!sessionToken) {
+    const loginUrl = new URL('/', request.url);
+    loginUrl.searchParams.set('redirect', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};


### PR DESCRIPTION
## Summary

- Migrate `nav.jsx` from `react-icons/fa6` to `lucide-react` named equivalents (Wallet, Bell, CircleUser, LogOut), eliminating the `react-icons` bundle contribution entirely. Add `experimental.optimizePackageImports: ['lucide-react']` to `next.config.ts` so Next.js applies automatic per-icon code-splitting — only icons actually rendered are included in the production JS output (#110)
- Create `src/middleware.ts` that intercepts all `/admin/*` requests at the edge before any page component begins rendering. If the `sf_admin_session` cookie is absent the request is immediately redirected to `/` with the original path preserved as a `redirect` query param, eliminating the content-flicker race condition. Zero overhead on non-admin routes via `matcher` config (#94)

## Issues

Closes #110
Closes #94

## Test plan

- [ ] Build and inspect bundle — `react-icons` chunk no longer appears in `.next/static`
- [ ] Navigate to `/admin/settings` without the cookie — should redirect to `/`
- [ ] Set `sf_admin_session` cookie and navigate to `/admin/settings` — page loads normally
- [ ] All nav icons render correctly (Wallet, Bell, CircleUser, LogOut)