### PR TITLE
feat: implement useErrorTimeout hook for automatic error clearing in …

### DIFF
--- a/docs/ERROR_TIMEOUT_MANAGEMENT.md
+++ b/docs/ERROR_TIMEOUT_MANAGEMENT.md
@@ -1,0 +1,177 @@
+# Error Timeout Management - StellarFlow Frontend
+
+## Overview
+
+This feature implements automatic timeout-based clearing of network error states to prevent stale errors from lingering in the application state and causing unnecessary fallback checks or misleading error displays.
+
+## Problem Statement
+
+Previously, when network errors occurred (WebSocket disconnections, API failures), the error state would persist until:
+- A successful connection/request was made
+- The component was unmounted/remounted
+
+This caused the UI to display outdated error messages and the application logic to perform unnecessary fallback checks even after the network issue had resolved.
+
+## Solution
+
+### New Hook: `useErrorTimeout`
+
+Located in: [`src/app/hooks/useErrorTimeout.ts`](src/app/hooks/useErrorTimeout.ts)
+
+A custom React hook that manages error state with automatic timeout-based clearing.
+
+#### API
+
+```typescript
+interface UseErrorTimeoutOptions {
+  /**
+   * Timeout in milliseconds before automatically clearing the error.
+   * Set to 0 to disable auto-clear (error must be manually cleared).
+   * @default 5000
+   */
+  timeoutMs?: number
+}
+
+interface UseErrorTimeoutReturn {
+  error: string | null
+  setError: (error: string | null) => void
+  clearError: () => void
+}
+
+function useErrorTimeout(options?: UseErrorTimeoutOptions): UseErrorTimeoutReturn
+```
+
+#### Usage Example
+
+```typescript
+const { error, setError, clearError } = useErrorTimeout({ timeoutMs: 5000 })
+
+try {
+  await fetchData()
+} catch (err) {
+  setError('Failed to fetch data')  // Auto-clears after 5 seconds
+}
+
+// Or manually clear
+clearError()
+```
+
+#### Features
+
+- **Automatic clearing**: Errors automatically clear after the specified timeout (default: 5000ms)
+- **Configurable timeout**: Set `timeoutMs` to any value, or `0` to disable auto-clear
+- **Prevents stale errors**: New errors cancel previous timeouts automatically
+- **Explicit clearing**: Call `clearError()` to manually clear errors immediately
+- **Cleanup on unmount**: Automatically clears pending timeouts when component unmounts
+
+### Updated Components
+
+#### 1. **useSocket Hook**
+- **File**: [`src/app/hooks/useSocket.ts`](src/app/hooks/useSocket.ts)
+- **Changes**:
+  - Added `errorTimeoutMs` option to `UseSocketOptions` (default: 5000ms)
+  - Replaced `useState` error with `useErrorTimeout` hook
+  - WebSocket errors now auto-clear after 5 seconds if not replaced by a new error or successful connection
+
+#### 2. **Map Component**
+- **File**: [`src/app/components/Map.tsx`](src/app/components/Map.tsx)
+- **Changes**:
+  - Replaced `useState` error with `useErrorTimeout` hook (5000ms timeout)
+  - Map loading errors now auto-clear after 5 seconds
+
+#### 3. **PriceFeedCard Component**
+- **File**: [`src/app/components/PriceFeedCard.tsx`](src/app/components/PriceFeedCard.tsx)
+- **Changes**:
+  - Replaced `useState` error with `useErrorTimeout` hook (5000ms timeout)
+  - Price feed fetch errors now auto-clear after 5 seconds
+  - WebSocket errors in the card now also benefit from auto-clearing
+
+## Configuration
+
+### Default Timeout Values
+
+All components use a **5-second (5000ms)** timeout by default. This can be customized:
+
+```typescript
+// In useSocket
+const { error } = useSocket({ 
+  errorTimeoutMs: 10000  // Clear errors after 10 seconds
+})
+
+// In Map component (update the hook call)
+const { error, setError } = useErrorTimeout({ timeoutMs: 10000 })
+
+// In PriceFeedCard (update the hook call)
+const { error, setError } = useErrorTimeout({ timeoutMs: 10000 })
+```
+
+## Error Lifecycle
+
+### When Error is Set
+1. Previous timeout (if any) is cancelled
+2. Error state is updated
+3. New timeout is scheduled (unless `timeoutMs` is 0)
+
+### When Timeout Completes
+1. Error is automatically cleared from state
+2. Component re-renders with `error === null`
+3. UI fallback states are cleared (if conditional on error)
+
+### When New Error Occurs Before Timeout
+1. Previous timeout is cancelled
+2. New error replaces the old one
+3. New timeout is scheduled
+
+### When Connection Succeeds
+1. Error is explicitly set to `null` (e.g., `wsRef.current.onopen`)
+2. Previous timeout is cancelled
+3. No new timeout is scheduled
+
+## Benefits
+
+✅ **Improved UX**: Stale error messages don't linger after network issues resolve
+✅ **Reduced API Calls**: Fewer unnecessary fallback/retry attempts
+✅ **Cleaner State Management**: Automatic cleanup prevents memory leaks
+✅ **Configurable**: Each use case can have its own timeout value
+✅ **Reusable**: The `useErrorTimeout` hook can be used throughout the app
+
+## Testing
+
+### Manual Testing
+
+1. **WebSocket errors**: Disconnect network and reconnect; error should clear after 5 seconds
+2. **Map errors**: Provide invalid geojson URL; error should clear after 5 seconds
+3. **API errors**: Temporarily disable API endpoint; error should clear after 5 seconds
+
+### Example Test Component
+
+```typescript
+import { useErrorTimeout } from '../hooks/useErrorTimeout'
+
+export function TestErrorTimeout() {
+  const { error, setError, clearError } = useErrorTimeout({ timeoutMs: 3000 })
+
+  return (
+    <div>
+      {error && <p>Error: {error}</p>}
+      <button onClick={() => setError('Test error')}>Set Error</button>
+      <button onClick={() => clearError()}>Clear Error</button>
+    </div>
+  )
+}
+```
+
+## Related Files
+
+- Core implementation: [`src/app/hooks/useErrorTimeout.ts`](src/app/hooks/useErrorTimeout.ts)
+- WebSocket integration: [`src/app/hooks/useSocket.ts`](src/app/hooks/useSocket.ts)
+- Map component: [`src/app/components/Map.tsx`](src/app/components/Map.tsx)
+- Price feed component: [`src/app/components/PriceFeedCard.tsx`](src/app/components/PriceFeedCard.tsx)
+
+## Future Enhancements
+
+- Add exponential backoff for retries
+- Implement error retry buttons with auto-reset
+- Create error queue for batch processing
+- Add analytics tracking for error occurrences
+- Implement different timeout values for different error types

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -3,6 +3,7 @@
 import "leaflet/dist/leaflet.css";
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+import { useErrorTimeout } from "../hooks/useErrorTimeout";
 
 // Dynamically import map components to avoid SSR issues
 const MapContainer = dynamic(() => import("react-leaflet").then((mod) => mod.MapContainer), { ssr: false });
@@ -18,7 +19,7 @@ interface NetworkNode {
 export default function Map() {
   const [geoData, setGeoData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { error, setError } = useErrorTimeout({ timeoutMs: 5000 });
 
   useEffect(() => {
     const loadMapData = async () => {

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { RefreshCw } from "lucide-react";
 import { useProgressBar } from "./TopLoadingBar";
 import { useDebounce } from "../hooks/useDebounce";
+import { useErrorTimeout } from "../hooks/useErrorTimeout";
 import { useSocketConnection, useSocketData } from "./providers/SocketProvider";
 import { Shimmer } from "@/components/skeletons/Shimmer";
 
@@ -92,7 +93,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
 }) => {
   const [data, setData] = useState<PriceFeedData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { error, setError } = useErrorTimeout({ timeoutMs: 5000 });
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [filterInput, setFilterInput] = useState("");

--- a/src/app/hooks/useErrorTimeout.ts
+++ b/src/app/hooks/useErrorTimeout.ts
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+export interface UseErrorTimeoutOptions {
+  /**
+   * Timeout in milliseconds before automatically clearing the error.
+   * Set to 0 to disable auto-clear (error must be manually cleared).
+   * @default 5000
+   */
+  timeoutMs?: number
+}
+
+export interface UseErrorTimeoutReturn {
+  error: string | null
+  setError: (error: string | null) => void
+  clearError: () => void
+}
+
+/**
+ * Hook for managing error state with automatic timeout clearing.
+ *
+ * This prevents stale error states from lingering in the application and causing
+ * unnecessary fallback checks or misleading error displays.
+ *
+ * @example
+ * const { error, setError } = useErrorTimeout({ timeoutMs: 5000 })
+ *
+ * try {
+ *   await fetchData()
+ * } catch (err) {
+ *   setError('Failed to fetch')  // Auto-clears after 5 seconds
+ * }
+ */
+export function useErrorTimeout({
+  timeoutMs = 5000,
+}: UseErrorTimeoutOptions = {}): UseErrorTimeoutReturn {
+  const [error, setErrorState] = useState<string | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Store timeoutMs in ref so it's always accessible in callbacks
+  const timeoutMsRef = useRef(timeoutMs)
+  useEffect(() => {
+    timeoutMsRef.current = timeoutMs
+  }, [timeoutMs])
+
+  // Clear any pending timeout (used internally)
+  const clearPendingTimeout = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  // Set error and schedule auto-clear
+  const setError = useCallback(
+    (newError: string | null) => {
+      clearPendingTimeout()
+
+      if (newError === null) {
+        setErrorState(null)
+        return
+      }
+
+      setErrorState(newError)
+
+      // Only schedule auto-clear if timeoutMs > 0
+      if (timeoutMsRef.current > 0) {
+        timeoutRef.current = setTimeout(() => {
+          setErrorState(null)
+          timeoutRef.current = null
+        }, timeoutMsRef.current)
+      }
+    },
+    [clearPendingTimeout],
+  )
+
+  // Explicit clear function
+  const clearError = useCallback(() => {
+    clearPendingTimeout()
+    setErrorState(null)
+  }, [clearPendingTimeout])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      clearPendingTimeout()
+    }
+  }, [clearPendingTimeout])
+
+  return { error, setError, clearError }
+}

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { PriceData } from '@/types'
+import { useErrorTimeout } from './useErrorTimeout'
 
 interface SocketMessage {
   type: 'price_update' | 'delta_update'
@@ -15,6 +16,12 @@ export interface UseSocketOptions {
   enableDeltaUpdates?: boolean
   reconnectInterval?: number
   maxReconnectAttempts?: number
+  /**
+   * Timeout in milliseconds before automatically clearing WebSocket errors.
+   * Set to 0 to disable auto-clear. Defaults to 5000ms.
+   * @default 5000
+   */
+  errorTimeoutMs?: number
 }
 
 interface UseSocketReturn {
@@ -33,11 +40,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     assetIds = [],
     reconnectInterval = 3000,
     maxReconnectAttempts = 5,
+    errorTimeoutMs = 5000,
   } = options
 
   const [isConnected, setIsConnected] = useState(false)
   const [lastUpdate, setLastUpdate] = useState<PriceData | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const { error, setError } = useErrorTimeout({ timeoutMs: errorTimeoutMs })
   const [reconnectAttempts, setReconnectAttempts] = useState(0)
 
   const wsRef = useRef<WebSocket | null>(null)


### PR DESCRIPTION
# closes #175 

Description

Implements automatic timeout-based clearing of stale network error states to prevent the interface loop from processing unnecessary fallback checks.

Problem

Previously, when network errors occurred (WebSocket disconnections, API failures), error states would persist in memory until:
- A successful connection/request was made
- The component was unmounted/remounted

This caused:
- Misleading error displays after the issue had resolved
- Unnecessary fallback checks running repeatedly
- Stale error states cluttering application memory

 Solution

New Hook: `useErrorTimeout`
Created a reusable custom hook (`src/app/hooks/useErrorTimeout.ts`) that:
- Automatically clears error state after a configurable timeout (default: **5 seconds**)
- Cancels previous timeouts when new errors occur
- Provides explicit `clearError()` for immediate clearing
- Cleans up pending timeouts on component unmount
- Sets timeout to `0` to disable auto-clear when needed

Updated Components
1. useSocket Hook(`src/app/hooks/useSocket.ts`)
   - Added `errorTimeoutMs` option to `UseSocketOptions`
   - WebSocket connection errors now auto-clear after 5 seconds
   - Prevents stale connection errors from blocking reconnection logic

2. Map Component (`src/app/components/Map.tsx`)
   - GeoJSON loading errors auto-clear after 5 seconds
   - Cleaner error display lifecycle

3. PriceFeedCard Component (`src/app/components/PriceFeedCard.tsx`)
   - REST API fetch errors auto-clear after 5 seconds
   - WebSocket errors also benefit from auto-clearing
   - Prevents unnecessary fallback polling triggers

Technical Details

Error Lifecycle