### PR TITLE
perf(#154): replace split address arrays with O(1) Record lookups

### DIFF
--- a/src/app/relayers/page.tsx
+++ b/src/app/relayers/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo } from 'react';
 import { useDebounce } from '../hooks/useDebounce';
+import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
 import { 
   Activity, 
   Plus, 
@@ -43,8 +44,10 @@ export default function RelayersPage() {
   }, [debouncedSearch]);
 
   // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
-  const transformedRelayers = useMemo(
-    () => useTransformedCustomAddressField(MOCK_RELAYERS, 'address'),
+  const shortenedAddressMap = useMemo<Record<string, string>>(
+    () => Object.fromEntries(
+      useTransformedCustomAddressField(MOCK_RELAYERS, 'address').map(r => [r.id, r.shortenedAddress])
+    ),
     []
   );
 
@@ -105,8 +108,8 @@ export default function RelayersPage() {
                 <tr key={relayer.id} className="hover:bg-[#1c2128] transition-colors group">
                   <td className="px-6 py-4">
                     <div className="font-medium text-blue-400">{relayer.name}</div>
-                    {/* PERFORMANCE OPTIMIZATION: Use pre-computed shortened address instead of runtime string slicing */}
-                    <div className="text-xs text-gray-500 font-mono">{relayer.shortenedAddress}</div>
+                    {/* PERFORMANCE OPTIMIZATION: O(1) map lookup instead of O(n) array scan */}
+                    <div className="text-xs text-gray-500 font-mono">{shortenedAddressMap[relayer.id]}</div>
                   </td>
                   <td className="px-6 py-4">
                     <StatusBadge status={relayer.status} />

--- a/src/app/staking/page.tsx
+++ b/src/app/staking/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo } from 'react';
 import { useDebounce } from '../hooks/useDebounce';
+import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
 import { 
   ShieldCheck, 
   Coins, 
@@ -50,8 +51,10 @@ export default function StakingPage() {
   }, [debouncedSearch]);
 
   // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
-  const transformedStakers = useMemo(
-    () => useTransformedCustomAddressField(MOCK_STAKERS, 'operatorAddress'),
+  const shortenedAddressMap = useMemo<Record<string, string>>(
+    () => Object.fromEntries(
+      useTransformedCustomAddressField(MOCK_STAKERS, 'operatorAddress').map(s => [s.id, s.shortenedAddress])
+    ),
     []
   );
 
@@ -118,8 +121,8 @@ export default function StakingPage() {
                 <tr key={node.id} className="hover:bg-[#1c2128] transition-colors group">
                   <td className="px-6 py-4">
                     <div className="font-medium text-gray-200">{node.nodeName}</div>
-                    {/* PERFORMANCE OPTIMIZATION: Use pre-computed shortened address instead of runtime string slicing */}
-                    <div className="text-xs text-gray-500 font-mono">{node.shortenedAddress}</div>
+                    {/* PERFORMANCE OPTIMIZATION: O(1) map lookup instead of O(n) array scan */}
+                    <div className="text-xs text-gray-500 font-mono">{shortenedAddressMap[node.id]}</div>
                   </td>
                   <td className="px-6 py-4 text-sm font-mono text-gray-300">
                     {node.stakedAmountXLM.toLocaleString()} XLM


### PR DESCRIPTION
Closes #154 
  
  Eliminates O(n) array scans for address lookups in staking and relayer 
  components by transforming the voter/address arrays into a flat 
  `Record<id, shortenedAddress>` built once at data ingestion.
  
  ## Root Cause
  
  Both `staking/page.tsx` and `relayers/page.tsx` had a split-array bug:
  the render loop iterated the search-filtered array (`displayedStakers` / 
  `displayedRelayers`) but accessed `.shortenedAddress`, which only existed 
  on a separate transformed array. This meant `shortenedAddress` was always 
  `undefined` at render time, and correlating the two arrays at scale would 
  require an O(n) scan per row.
  
  ## Changes
  
  - **`staking/page.tsx`** — added missing `useTransformedCustomAddressField` 
    import; replaced `transformedStakers` array with 
    `shortenedAddressMap: Record<id, shortenedAddress>` built once in `useMemo`; 
    render now uses `shortenedAddressMap[node.id]` (O(1)).
  - **`relayers/page.tsx`** — same fix; render now uses 
    `shortenedAddressMap[relayer.id]` (O(1)).
  
  ## Notes
  
  - `consumers/page.tsx` and `governance/page.tsx` are unaffected — they 
    iterate the transformed array directly with no split-array pattern.
  - No new dependencies introduced.
