### PR TITLE
fix: add content visibility to heavy sections

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -92,7 +92,10 @@ async function fetchLiveRate(providerRpcUrl) {
         
         {/* --- Left Column: Documentation Outline --- */}
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-[#161b22] border border-gray-800 rounded-xl p-6">
+          <div
+            className="content-visibility-auto bg-[#161b22] border border-gray-800 rounded-xl p-6"
+            style={{ '--content-visibility-fallback': '1px 320px' } as React.CSSProperties}
+          >
             <h2 className="text-sm font-bold uppercase text-gray-400 tracking-wider mb-4 flex items-center gap-2">
               <BookOpen size={16} className="text-blue-400" />
               Integration Invariants
@@ -120,7 +123,10 @@ async function fetchLiveRate(providerRpcUrl) {
           </div>
 
           {/* --- Live Interactive On-Chain Invoker Box --- */}
-          <div className="bg-[#161b22] border border-gray-800 rounded-xl p-6">
+          <div
+            className="content-visibility-auto bg-[#161b22] border border-gray-800 rounded-xl p-6"
+            style={{ '--content-visibility-fallback': '1px 280px' } as React.CSSProperties}
+          >
             <h2 className="text-sm font-bold uppercase text-gray-400 tracking-wider mb-2 flex items-center gap-2">
               <Cpu size={16} className="text-purple-400" />
               Soroban RPC Invoker Playground
@@ -146,7 +152,10 @@ async function fetchLiveRate(providerRpcUrl) {
 
         {/* --- Right Column: Interactive Code Workspace --- */}
         <div className="lg:col-span-2 space-y-6">
-          <div className="bg-[#161b22] border border-gray-800 rounded-xl overflow-hidden flex flex-col h-full">
+          <div
+            className="content-visibility-auto bg-[#161b22] border border-gray-800 rounded-xl overflow-hidden flex flex-col h-full"
+            style={{ '--content-visibility-fallback': '1px 520px' } as React.CSSProperties}
+          >
             
             {/* Tab Controller Bar */}
             <div className="bg-[#0d1117] px-4 pt-3 border-b border-gray-800 flex justify-between items-center">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,11 @@ body {
   overflow-x: hidden;
 }
 
+.content-visibility-auto {
+  content-visibility: auto;
+  contain-intrinsic-size: var(--content-visibility-fallback, 1px 480px);
+}
+
 .wallet-btn {
   background-color: #d9f99d;
   color: #1f2937;

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -152,13 +152,19 @@ export default function DashboardPage() {
           </section>
 
           {/* Relayer Status Table */}
-          <section className="space-y-4">
+          <section
+            className="content-visibility-auto space-y-4"
+            style={{ "--content-visibility-fallback": "1px 220px" }}
+          >
             <h2 className="text-xl font-semibold text-white uppercase tracking-wider mb-4">
               Relayer Network Status
             </h2>
             <RelayerStatusTable relayers={mockRelayers} />
           </section>
-          <section className="space-y-4">
+          <section
+            className="content-visibility-auto space-y-4"
+            style={{ "--content-visibility-fallback": "1px 520px" }}
+          >
             <h2 className="text-xl font-semibold text-white uppercase tracking-wider mb-4">
               Live Network Map
             </h2>
@@ -180,7 +186,10 @@ export default function DashboardPage() {
           </section>
 
           {/* Chart loading state and source table shell */}
-          <section className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
+          <section
+            className="content-visibility-auto grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]"
+            style={{ "--content-visibility-fallback": "1px 620px" }}
+          >
             <div className="rounded-[32px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
               <div className="mb-5 flex items-center justify-between gap-4 border-b border-white/10 pb-4">
                 <div>


### PR DESCRIPTION
This PR addresses #179 by adding a reusable content-visibility: auto utility with contain-intrinsic-size fallbacks, then applying it to heavier documentation and lower-page dashboard/list sections so the browser can skip rendering off-screen content during initial page load while preserving stable scroll sizing.
closes #179 