### PR TITLE
perf: offload oracle payload hashing to WebCrypto worker (#164)

### DIFF
--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from "../hooks/useDebounce";
 import { useErrorTimeout } from "../hooks/useErrorTimeout";
 import { useSocketConnection, useSocketData } from "./providers/SocketProvider";
 import { Shimmer } from "@/components/skeletons/Shimmer";
+import { useCryptoWorker } from "@/utils/crypto";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -105,8 +106,10 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [filterInput, setFilterInput] = useState("");
+  const [payloadHash, setPayloadHash] = useState<string | null>(null);
   const debouncedFilter = useDebounce(filterInput, 250);
   const { start, done } = useProgressBar();
+  const { hash } = useCryptoWorker();
 
   // Granular context subscriptions — each hook only re-renders this component
   // when its specific slice changes, not on every unrelated socket event.
@@ -173,6 +176,14 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
       setError(`WebSocket error: ${wsError}`);
     }
   }, [wsError, enableWebSocket]);
+
+  // Hash the oracle payload off-thread whenever data updates
+  useEffect(() => {
+    if (!data) return;
+    hash(JSON.stringify(data)).then(({ hex }) =>
+      setPayloadHash(hex.slice(0, 16))
+    );
+  }, [data, hash]);
 
   // Initial fetch + fallback polling (only when WebSocket is disabled or disconnected)
   const pollingActive = !enableWebSocket || !isConnected;
@@ -372,6 +383,14 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
           STELLARFLOW ORACLE
         </span>
       </div>
+      {payloadHash && (
+        <div className="relative mt-1 flex items-center gap-1.5">
+          <span className="text-[8px] text-gray-700 font-mono">SHA-256</span>
+          <span className="text-[8px] text-[#39FF14]/40 font-mono tracking-wider">
+            {payloadHash}…
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/utils/crypto/crypto-worker.ts
+++ b/src/utils/crypto/crypto-worker.ts
@@ -1,0 +1,96 @@
+/// <reference lib="webworker" />
+
+/**
+ * crypto-worker.ts
+ *
+ * Off-thread Web Worker for cryptographic hashing via the native WebCrypto API
+ * (crypto.subtle). Keeps all digest computation off the main UI thread so
+ * frame rendering is never blocked during verification of oracle data strings.
+ *
+ * Supported algorithms: SHA-256 (default), SHA-384, SHA-512
+ *
+ * Inbound message types:
+ *   HASH        – hash a single string
+ *   BATCH_HASH  – hash an array of strings in one shot
+ *
+ * Outbound message types:
+ *   HASH_RESULT       – success result for HASH
+ *   BATCH_HASH_RESULT – success result for BATCH_HASH
+ *   HASH_ERROR        – failure with reason string
+ */
+
+export type HashAlgorithm = 'SHA-256' | 'SHA-384' | 'SHA-512';
+
+interface HashPayload {
+  id: string;
+  input: string;
+  algorithm?: HashAlgorithm;
+}
+
+interface BatchHashPayload {
+  batchId: string;
+  items: HashPayload[];
+}
+
+type InboundMessage =
+  | { type: 'HASH'; payload: HashPayload }
+  | { type: 'BATCH_HASH'; payload: BatchHashPayload };
+
+interface HashResult {
+  id: string;
+  hex: string;
+  algorithm: HashAlgorithm;
+}
+
+// ─── Core hash logic ──────────────────────────────────────────────────────────
+
+async function hashString(
+  id: string,
+  input: string,
+  algorithm: HashAlgorithm = 'SHA-256',
+): Promise<HashResult> {
+  const encoded = new TextEncoder().encode(input);
+  const buffer = await crypto.subtle.digest(algorithm, encoded);
+  const hex = Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { id, hex, algorithm };
+}
+
+// ─── Message handler ──────────────────────────────────────────────────────────
+
+self.onmessage = async (event: MessageEvent<InboundMessage>) => {
+  const { type, payload } = event.data;
+
+  if (type === 'HASH') {
+    const { id, input, algorithm } = payload as HashPayload;
+    try {
+      const result = await hashString(id, input, algorithm);
+      self.postMessage({ type: 'HASH_RESULT', payload: result });
+    } catch (err) {
+      self.postMessage({
+        type: 'HASH_ERROR',
+        payload: { id, error: err instanceof Error ? err.message : String(err) },
+      });
+    }
+    return;
+  }
+
+  if (type === 'BATCH_HASH') {
+    const { batchId, items } = payload as BatchHashPayload;
+    const results = await Promise.all(
+      items.map(({ id, input, algorithm }) =>
+        hashString(id, input, algorithm).catch((err) => ({
+          id,
+          hex: '',
+          algorithm: algorithm ?? ('SHA-256' as HashAlgorithm),
+          error: err instanceof Error ? err.message : String(err),
+        })),
+      ),
+    );
+    self.postMessage({ type: 'BATCH_HASH_RESULT', payload: { batchId, results } });
+    return;
+  }
+
+  console.warn('[crypto-worker] Unknown message type:', (event.data as { type: string }).type);
+};

--- a/src/utils/crypto/index.ts
+++ b/src/utils/crypto/index.ts
@@ -1,0 +1,2 @@
+export { useCryptoWorker } from './useCryptoWorker';
+export type { HashAlgorithm } from './crypto-worker';

--- a/src/utils/crypto/useCryptoWorker.ts
+++ b/src/utils/crypto/useCryptoWorker.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { HashAlgorithm } from './crypto-worker';
+
+interface HashResult {
+  id: string;
+  hex: string;
+  algorithm: HashAlgorithm;
+  error?: string;
+}
+
+interface BatchHashResult {
+  batchId: string;
+  results: HashResult[];
+}
+
+type PendingHash = (result: HashResult) => void;
+type PendingBatch = (result: BatchHashResult) => void;
+
+/**
+ * useCryptoWorker
+ *
+ * React hook that spawns a single crypto Web Worker and exposes `hash` /
+ * `batchHash` helpers. All digest work runs off the main thread via the
+ * native WebCrypto API (crypto.subtle).
+ *
+ * @example
+ * const { hash } = useCryptoWorker();
+ * const { hex } = await hash('oracle-payload-string');
+ */
+export function useCryptoWorker() {
+  const workerRef = useRef<Worker | null>(null);
+  const pendingHashRef = useRef<Map<string, PendingHash>>(new Map());
+  const pendingBatchRef = useRef<Map<string, PendingBatch>>(new Map());
+
+  useEffect(() => {
+    const worker = new Worker(new URL('./crypto-worker.ts', import.meta.url));
+
+    worker.onmessage = (event: MessageEvent) => {
+      const { type, payload } = event.data as {
+        type: string;
+        payload: HashResult & { batchId?: string; results?: HashResult[] };
+      };
+
+      if (type === 'HASH_RESULT' || type === 'HASH_ERROR') {
+        const resolve = pendingHashRef.current.get(payload.id);
+        if (resolve) {
+          pendingHashRef.current.delete(payload.id);
+          resolve(payload as HashResult);
+        }
+        return;
+      }
+
+      if (type === 'BATCH_HASH_RESULT' && payload.batchId) {
+        const resolve = pendingBatchRef.current.get(payload.batchId);
+        if (resolve) {
+          pendingBatchRef.current.delete(payload.batchId);
+          resolve({ batchId: payload.batchId, results: payload.results ?? [] });
+        }
+      }
+    };
+
+    workerRef.current = worker;
+    return () => worker.terminate();
+  }, []);
+
+  /** Hash a single string. Returns the hex digest and algorithm used. */
+  const hash = useCallback(
+    (input: string, algorithm: HashAlgorithm = 'SHA-256'): Promise<HashResult> =>
+      new Promise((resolve, reject) => {
+        if (!workerRef.current) {
+          reject(new Error('Crypto worker not initialized'));
+          return;
+        }
+        const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        pendingHashRef.current.set(id, resolve);
+        workerRef.current.postMessage({ type: 'HASH', payload: { id, input, algorithm } });
+      }),
+    [],
+  );
+
+  /** Hash multiple strings in one worker round-trip. */
+  const batchHash = useCallback(
+    (
+      items: Array<{ id: string; input: string; algorithm?: HashAlgorithm }>,
+    ): Promise<HashResult[]> =>
+      new Promise((resolve, reject) => {
+        if (!workerRef.current) {
+          reject(new Error('Crypto worker not initialized'));
+          return;
+        }
+        const batchId = `batch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        pendingBatchRef.current.set(batchId, ({ results }) => resolve(results));
+        workerRef.current.postMessage({
+          type: 'BATCH_HASH',
+          payload: { batchId, items },
+        });
+      }),
+    [],
+  );
+
+  return { hash, batchHash };
+}


### PR DESCRIPTION
## Summary
Closes #164

Delegates cryptographic hash computation to a dedicated Web Worker using the native `crypto.subtle` WebCrypto API, keeping the main thread free for rendering.

## Changes
- `src/utils/crypto/crypto-worker.ts` — Web Worker that runs `crypto.subtle.digest()` off-thread; supports SHA-256 (default), SHA-384, SHA-512 with single and batch modes
- `src/utils/crypto/useCryptoWorker.ts` — React hook that spawns one worker per component, exposes `hash()` and `batchHash()` with stable `useCallback` identities
- `src/utils/crypto/index.ts` — barrel export
- `src/app/components/PriceFeedCard.tsx` — consumes `useCryptoWorker` to hash oracle payloads on each data update; displays truncated SHA-256 digest in card footer

## What was tested
- Dev server runs without errors
- SHA-256 digest renders in the NGN/XLM Price Feed card footer and updates on each data tick
- No type errors in crypto files