### PR TITLE
Perf/pause live streams when hidden

### DIFF
--- a/src/app/components/AdminTabBar.tsx
+++ b/src/app/components/AdminTabBar.tsx
@@ -1,24 +1,26 @@
 "use client";
 
-import React, { useState, memo } from "react";
-import {
-  Radio,
-  FileCheck2,
-  Network,
-  SlidersHorizontal,
-} from "lucide-react";
+import React, { memo, useState } from "react";
 
 interface Tab {
   id: string;
   label: string;
-  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+  iconId: string;
 }
 
 const adminTabs: Tab[] = [
-  { id: "live-oracle", label: "Live Oracle", icon: Radio },
-  { id: "contract-status", label: "Contract Status", icon: FileCheck2 },
-  { id: "data-relayers", label: "Data Relayers", icon: Network },
-  { id: "admin-settings", label: "Admin Settings", icon: SlidersHorizontal },
+  { id: "live-oracle", label: "Live Oracle", iconId: "admin-icon-radio" },
+  {
+    id: "contract-status",
+    label: "Contract Status",
+    iconId: "admin-icon-file-check",
+  },
+  { id: "data-relayers", label: "Data Relayers", iconId: "admin-icon-network" },
+  {
+    id: "admin-settings",
+    label: "Admin Settings",
+    iconId: "admin-icon-sliders",
+  },
 ];
 
 interface AdminTabBarProps {
@@ -28,13 +30,86 @@ interface AdminTabBarProps {
   onTabChange?: (tabId: string) => void;
 }
 
+function AdminIconDefs() {
+  return (
+    <svg
+      width="0"
+      height="0"
+      aria-hidden="true"
+      focusable="false"
+      style={{ position: "absolute" }}
+    >
+      <defs>
+        <symbol id="admin-icon-radio" viewBox="0 0 24 24">
+          <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9" />
+          <path d="M7.8 16.2a6 6 0 0 1 0-8.5" />
+          <circle cx="12" cy="12" r="2" />
+          <path d="M16.2 7.8a6 6 0 0 1 0 8.5" />
+          <path d="M19.1 4.9c3.9 3.9 3.9 10.2 0 14.1" />
+        </symbol>
+
+        <symbol id="admin-icon-file-check" viewBox="0 0 24 24">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path d="M14 2v6h6" />
+          <path d="m9 15 2 2 4-4" />
+        </symbol>
+
+        <symbol id="admin-icon-network" viewBox="0 0 24 24">
+          <rect x="16" y="16" width="6" height="6" rx="1" />
+          <rect x="2" y="16" width="6" height="6" rx="1" />
+          <rect x="9" y="2" width="6" height="6" rx="1" />
+          <path d="M12 8v4" />
+          <path d="M5 16v-2a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v2" />
+        </symbol>
+
+        <symbol id="admin-icon-sliders" viewBox="0 0 24 24">
+          <path d="M21 4H14" />
+          <path d="M10 4H3" />
+          <path d="M21 12H12" />
+          <path d="M8 12H3" />
+          <path d="M21 20H16" />
+          <path d="M12 20H3" />
+          <circle cx="12" cy="4" r="2" />
+          <circle cx="10" cy="12" r="2" />
+          <circle cx="14" cy="20" r="2" />
+        </symbol>
+      </defs>
+    </svg>
+  );
+}
+
+function AdminTabIcon({
+  iconId,
+  isActive,
+}: {
+  iconId: string;
+  isActive: boolean;
+}) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={isActive ? 2.2 : 1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <use href={`#${iconId}`} />
+    </svg>
+  );
+}
+
 const AdminTabBar = ({
   activeTab: controlledActiveTab,
   onTabChange,
-}: AdminTabBarProps) {
+}: AdminTabBarProps) => {
   const [internalActiveTab, setInternalActiveTab] = useState("live-oracle");
+  const activeTab = controlledActiveTab ?? internalActiveTab;
 
-export default memo(AdminTabBar);
   const handleTabClick = (tabId: string) => {
     if (onTabChange) {
       onTabChange(tabId);
@@ -45,8 +120,14 @@ export default memo(AdminTabBar);
 
   return (
     <div className="admin-tabbar-wrapper">
-      <nav className="admin-tabbar" role="tablist" aria-label="Admin navigation">
-        {adminTabs.map(({ id, label, icon: Icon }) => {
+      <AdminIconDefs />
+
+      <nav
+        className="admin-tabbar"
+        role="tablist"
+        aria-label="Admin navigation"
+      >
+        {adminTabs.map(({ id, label, iconId }) => {
           const isActive = activeTab === id;
 
           return (
@@ -60,18 +141,16 @@ export default memo(AdminTabBar);
               onClick={() => handleTabClick(id)}
               type="button"
             >
-              <Icon size={16} strokeWidth={isActive ? 2.2 : 1.6} />
+              <AdminTabIcon iconId={iconId} isActive={isActive} />
               <span>{label}</span>
 
-              {/* Cyber Lime active underline */}
-              <span
-                className="admin-tab__indicator"
-                aria-hidden="true"
-              />
+              <span className="admin-tab__indicator" aria-hidden="true" />
             </button>
           );
         })}
       </nav>
     </div>
   );
-}
+};
+
+export default memo(AdminTabBar);

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -143,7 +143,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   // instead of closing over `data` — so `data` is NOT a dependency and the
   // effect does not re-run after every state write, breaking the render cycle.
   useEffect(() => {
-    if (!wsUpdate || !enableWebSocket) return;
+    if (!wsUpdate || !enableWebSocket || !isPageVisible) return;
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setData((prev: PriceFeedData | null) => ({
@@ -175,7 +175,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   }, [wsError, enableWebSocket]);
 
   // Initial fetch + fallback polling (only when WebSocket is disabled or disconnected)
-  const pollingActive = !enableWebSocket || !isConnected;
+  const pollingActive = isPageVisible && (!enableWebSocket || !isConnected);
   useEffect(() => {
     if (pollingActive) load();
   }, [pollingActive, load]);
@@ -196,7 +196,22 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
     : "shadow-[0_0_18px_rgba(244,63,94,0.18)]";
 
   const priceColor = isUp ? "text-emerald-400" : "text-rose-400";
+  const [isPageVisible, setIsPageVisible] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState === "visible";
+  });
 
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsPageVisible(document.visibilityState === "visible");
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
   return (
     <div
       className={`

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -1,38 +1,38 @@
-'use client'
+"use client";
 
-import { useEffect, useRef, useState, useCallback } from 'react'
-import { PriceData } from '@/types'
-import { useErrorTimeout } from './useErrorTimeout'
+import { useEffect, useRef, useState, useCallback } from "react";
+import { PriceData } from "@/types";
+import { useErrorTimeout } from "./useErrorTimeout";
 
 interface SocketMessage {
-  type: 'price_update' | 'delta_update'
-  assetId?: string
-  data: PriceData | Partial<PriceData>
-  timestamp: number
+  type: "price_update" | "delta_update";
+  assetId?: string;
+  data: PriceData | Partial<PriceData>;
+  timestamp: number;
 }
 
 export interface UseSocketOptions {
-  assetIds?: string[]
-  enableDeltaUpdates?: boolean
-  reconnectInterval?: number
-  maxReconnectAttempts?: number
+  assetIds?: string[];
+  enableDeltaUpdates?: boolean;
+  reconnectInterval?: number;
+  maxReconnectAttempts?: number;
   /**
    * Timeout in milliseconds before automatically clearing WebSocket errors.
    * Set to 0 to disable auto-clear. Defaults to 5000ms.
    * @default 5000
    */
-  errorTimeoutMs?: number
+  errorTimeoutMs?: number;
 }
 
 interface UseSocketReturn {
-  isConnected: boolean
-  lastUpdate: PriceData | null
-  error: string | null
-  reconnectAttempts: number
-  subscribeToAsset: (assetId: string) => void
-  unsubscribeFromAsset: (assetId: string) => void
-  disconnect: () => void
-  reconnect: () => void
+  isConnected: boolean;
+  lastUpdate: PriceData | null;
+  error: string | null;
+  reconnectAttempts: number;
+  subscribeToAsset: (assetId: string) => void;
+  unsubscribeFromAsset: (assetId: string) => void;
+  disconnect: () => void;
+  reconnect: () => void;
 }
 
 export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
@@ -41,180 +41,241 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     reconnectInterval = 3000,
     maxReconnectAttempts = 5,
     errorTimeoutMs = 5000,
-  } = options
+  } = options;
 
-  const [isConnected, setIsConnected] = useState(false)
-  const [lastUpdate, setLastUpdate] = useState<PriceData | null>(null)
-  const { error, setError } = useErrorTimeout({ timeoutMs: errorTimeoutMs })
-  const [reconnectAttempts, setReconnectAttempts] = useState(0)
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastUpdate, setLastUpdate] = useState<PriceData | null>(null);
+  const { error, setError } = useErrorTimeout({ timeoutMs: errorTimeoutMs });
+  const [reconnectAttempts, setReconnectAttempts] = useState(0);
 
-  const wsRef = useRef<WebSocket | null>(null)
-  const subscribedAssetsRef = useRef<Set<string>>(new Set(assetIds))
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wsRef = useRef<WebSocket | null>(null);
+  const subscribedAssetsRef = useRef<Set<string>>(new Set(assetIds));
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const manuallyDisconnectedRef = useRef(false);
+  const pageVisibleRef = useRef(true);
 
   // Refs keep options fresh inside callbacks without triggering re-renders or
   // causing `connect` to be recreated on every tick.
-  const reconnectAttemptsRef = useRef(0)
-  const maxReconnectAttemptsRef = useRef(maxReconnectAttempts)
-  const reconnectIntervalRef = useRef(reconnectInterval)
+  const reconnectAttemptsRef = useRef(0);
+  const maxReconnectAttemptsRef = useRef(maxReconnectAttempts);
+  const reconnectIntervalRef = useRef(reconnectInterval);
 
   // Sync option refs after render so in-flight callbacks always see the
   // latest values without making `connect` depend on them directly.
   // (Assigning to .current during render is forbidden by the React Compiler.)
   useEffect(() => {
-    maxReconnectAttemptsRef.current = maxReconnectAttempts
-    reconnectIntervalRef.current = reconnectInterval
-  }, [maxReconnectAttempts, reconnectInterval])
+    maxReconnectAttemptsRef.current = maxReconnectAttempts;
+    reconnectIntervalRef.current = reconnectInterval;
+  }, [maxReconnectAttempts, reconnectInterval]);
 
   // `connect` has an empty dependency array because every value it needs is
   // accessed through a ref.  This breaks the cycle where a WS message would
   // update `lastUpdate` → recreate `connect` → effect fires → socket torn down.
   const connect = useCallback(function doConnect() {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      return
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "hidden"
+    ) {
+      return;
     }
 
-    try {
-      const protocol = process.env.NODE_ENV === 'production' ? 'wss:' : 'ws:'
-      const wsUrl = `${protocol}//${window.location.host}/ws`
+    pageVisibleRef.current = true;
+    manuallyDisconnectedRef.current = false;
 
-      wsRef.current = new WebSocket(wsUrl)
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return;
+    }
+    try {
+      const protocol = process.env.NODE_ENV === "production" ? "wss:" : "ws:";
+      const wsUrl = `${protocol}//${window.location.host}/ws`;
+
+      wsRef.current = new WebSocket(wsUrl);
 
       wsRef.current.onopen = () => {
-        setIsConnected(true)
-        setError(null)
-        reconnectAttemptsRef.current = 0
-        setReconnectAttempts(0)
+        setIsConnected(true);
+        setError(null);
+        reconnectAttemptsRef.current = 0;
+        setReconnectAttempts(0);
 
         if (subscribedAssetsRef.current.size > 0) {
           wsRef.current?.send(
             JSON.stringify({
-              type: 'subscribe',
+              type: "subscribe",
               assetIds: Array.from(subscribedAssetsRef.current),
             }),
-          )
+          );
         }
-      }
+      };
 
       wsRef.current.onmessage = (event: MessageEvent) => {
+        if (!pageVisibleRef.current) return;
+
         try {
-          const message: SocketMessage = JSON.parse(event.data as string)
+          const message: SocketMessage = JSON.parse(event.data as string);
 
           if (
-            message.type === 'price_update' ||
-            message.type === 'delta_update'
+            message.type === "price_update" ||
+            message.type === "delta_update"
           ) {
-            if (message.type === 'delta_update' && message.assetId) {
+            if (message.type === "delta_update" && message.assetId) {
               // Functional updater — reads current state without it becoming a
               // dependency of this callback.
               setLastUpdate((prev: PriceData | null) =>
                 prev
                   ? { ...prev, ...(message.data as PriceData) }
                   : (message.data as PriceData),
-              )
+              );
             } else {
-              setLastUpdate(message.data as PriceData)
+              setLastUpdate(message.data as PriceData);
             }
           }
         } catch (err) {
-          console.error('Failed to parse WebSocket message:', err)
+          console.error("Failed to parse WebSocket message:", err);
         }
-      }
+      };
 
       wsRef.current.onclose = (event: CloseEvent) => {
-        setIsConnected(false)
+        setIsConnected(false);
 
         // Use ref for reconnect counter — avoids stale closure.
         if (
           !event.wasClean &&
+          !manuallyDisconnectedRef.current &&
+          pageVisibleRef.current &&
           reconnectAttemptsRef.current < maxReconnectAttemptsRef.current
         ) {
-          reconnectAttemptsRef.current += 1
-          setReconnectAttempts(reconnectAttemptsRef.current)
+          reconnectAttemptsRef.current += 1;
+          setReconnectAttempts(reconnectAttemptsRef.current);
           reconnectTimeoutRef.current = setTimeout(() => {
-            doConnect()
-          }, reconnectIntervalRef.current)
+            doConnect();
+          }, reconnectIntervalRef.current);
         }
-      }
+      };
 
       wsRef.current.onerror = (event: Event) => {
-        setError('WebSocket connection error')
-        console.error('WebSocket error:', event)
-      }
+        setError("WebSocket connection error");
+        console.error("WebSocket error:", event);
+      };
     } catch (err) {
-      setError('Failed to establish WebSocket connection')
-      console.error('Connection error:', err)
+      setError("Failed to establish WebSocket connection");
+      console.error("Connection error:", err);
     }
-  }, []) // ← intentionally empty; all mutable values go through refs
+  }, []); // ← intentionally empty; all mutable values go through refs
 
   const disconnect = useCallback(() => {
+    manuallyDisconnectedRef.current = true;
+
     if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current)
-      reconnectTimeoutRef.current = null
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
     }
 
     if (wsRef.current) {
-      wsRef.current.close(1000, 'Manual disconnect')
-      wsRef.current = null
+      wsRef.current.close(1000, "Manual disconnect");
+      wsRef.current = null;
     }
 
-    setIsConnected(false)
-  }, [])
+    setIsConnected(false);
+  }, []);
 
   const reconnect = useCallback(() => {
-    disconnect()
-    reconnectAttemptsRef.current = 0
-    setReconnectAttempts(0)
-    setTimeout(connect, 100)
-  }, [disconnect, connect])
+    disconnect();
+    manuallyDisconnectedRef.current = false;
+    reconnectAttemptsRef.current = 0;
+    setReconnectAttempts(0);
+    setTimeout(connect, 100);
+  }, [disconnect, connect]);
 
   const subscribeToAsset = useCallback((assetId: string) => {
     if (!subscribedAssetsRef.current.has(assetId)) {
-      subscribedAssetsRef.current.add(assetId)
+      subscribedAssetsRef.current.add(assetId);
 
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(
-          JSON.stringify({ type: 'subscribe', assetIds: [assetId] }),
-        )
+          JSON.stringify({ type: "subscribe", assetIds: [assetId] }),
+        );
       }
     }
-  }, [])
+  }, []);
 
   const unsubscribeFromAsset = useCallback((assetId: string) => {
     if (subscribedAssetsRef.current.has(assetId)) {
-      subscribedAssetsRef.current.delete(assetId)
+      subscribedAssetsRef.current.delete(assetId);
 
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(
-          JSON.stringify({ type: 'unsubscribe', assetIds: [assetId] }),
-        )
+          JSON.stringify({ type: "unsubscribe", assetIds: [assetId] }),
+        );
       }
     }
-  }, [])
+  }, []);
 
   // Both `connect` and `disconnect` are now stable (empty dep arrays), so this
   // effect only runs once on mount and once on unmount — never on data ticks.
   useEffect(() => {
-    connect()
+    connect();
     return () => {
-      disconnect()
-    }
-  }, [connect, disconnect])
+      disconnect();
+    };
+  }, [connect, disconnect]);
 
   // Dedicated cleanup guard to ensure refs are released on unmount even if the
   // effect above runs in strict-mode double-invocation.
   useEffect(() => {
     return () => {
       if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current)
+        clearTimeout(reconnectTimeoutRef.current);
       }
       if (wsRef.current) {
-        wsRef.current.close(1000, 'Component unmount')
-        wsRef.current = null
+        wsRef.current.close(1000, "Component unmount");
+        wsRef.current = null;
       }
-    }
-  }, [])
+    };
+  }, []);
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const isVisible = document.visibilityState === "visible";
+      pageVisibleRef.current = isVisible;
 
+      if (!isVisible) {
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(
+            JSON.stringify({
+              type: "unsubscribe",
+              assetIds: Array.from(subscribedAssetsRef.current),
+            }),
+          );
+        }
+
+        if (wsRef.current) {
+          wsRef.current.close(1000, "Page hidden");
+          wsRef.current = null;
+        }
+
+        setIsConnected(false);
+        return;
+      }
+
+      if (!manuallyDisconnectedRef.current) {
+        reconnectAttemptsRef.current = 0;
+        setReconnectAttempts(0);
+        connect();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [connect]);
   return {
     isConnected,
     lastUpdate,
@@ -224,5 +285,5 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     unsubscribeFromAsset,
     disconnect,
     reconnect,
-  }
+  };
 }

--- a/src/app/relayers/page.tsx
+++ b/src/app/relayers/page.tsx
@@ -114,7 +114,7 @@ function RelayerIcon({
   size = 18,
   className,
 }: {
-  id: string;
+  id: (typeof RELAYER_ICON_IDS)[keyof typeof RELAYER_ICON_IDS];
   size?: number;
   className?: string;
 }) {

--- a/src/app/relayers/page.tsx
+++ b/src/app/relayers/page.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
-import { useDebounce } from '../hooks/useDebounce';
-import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
-import { 
-  Activity, 
-  Plus, 
-  Search, 
-  MoreVertical, 
-  RefreshCw, 
-  ShieldCheck, 
-  Clock, 
-  Signal 
-} from 'lucide-react';
-import { RELAYERS_PAGE_STATUS_VARIANTS } from '@/lib/classNameVariants';
+import React, { useState, useMemo } from "react";
+import { useDebounce } from "../hooks/useDebounce";
+import { useTransformedCustomAddressField } from "@/app/hooks/useTransformedData";
+import { RELAYERS_PAGE_STATUS_VARIANTS } from "@/lib/classNameVariants";
 
 // --- Types ---
 interface Relayer {
   id: string;
   name: string;
   address: string;
-  status: 'active' | 'lagging' | 'offline';
+  status: "active" | "lagging" | "offline";
   uptime: string;
   latency: number;
   successRate: number;
@@ -28,65 +18,222 @@ interface Relayer {
 
 // --- Mock Data ---
 const MOCK_RELAYERS: Relayer[] = [
-  { id: '1', name: 'VTPass Lagos', address: 'GA5THZLKMNPQRSXYZABCDEFGHIJKLMNBC9A', status: 'active', uptime: '99.98%', latency: 32, successRate: 99.4 },
-  { id: '2', name: 'Binance Pan-Africa', address: 'GBC2VHZLKMNPQRSXYZABCDEFGHIJKLMLOPA', status: 'lagging', uptime: '98.50%', latency: 540, successRate: 92.1 },
-  { id: '3', name: 'Coinbase Global', address: 'GDRTVHZLKMNPQRSXYZABCDEFGHIJKLM1122', status: 'active', uptime: '99.99%', latency: 45, successRate: 100 },
+  {
+    id: "1",
+    name: "VTPass Lagos",
+    address: "GA5THZLKMNPQRSXYZABCDEFGHIJKLMNBC9A",
+    status: "active",
+    uptime: "99.98%",
+    latency: 32,
+    successRate: 99.4,
+  },
+  {
+    id: "2",
+    name: "Binance Pan-Africa",
+    address: "GBC2VHZLKMNPQRSXYZABCDEFGHIJKLMLOPA",
+    status: "lagging",
+    uptime: "98.50%",
+    latency: 540,
+    successRate: 92.1,
+  },
+  {
+    id: "3",
+    name: "Coinbase Global",
+    address: "GDRTVHZLKMNPQRSXYZABCDEFGHIJKLM1122",
+    status: "active",
+    uptime: "99.99%",
+    latency: 45,
+    successRate: 100,
+  },
 ];
+const RELAYER_ICON_IDS = {
+  activity: "relayer-icon-activity",
+  plus: "relayer-icon-plus",
+  search: "relayer-icon-search",
+  moreVertical: "relayer-icon-more-vertical",
+  refresh: "relayer-icon-refresh",
+  shield: "relayer-icon-shield",
+  clock: "relayer-icon-clock",
+  signal: "relayer-icon-signal",
+} as const;
+
+function RelayerIconDefs() {
+  return (
+    <svg
+      width="0"
+      height="0"
+      aria-hidden="true"
+      focusable="false"
+      style={{ position: "absolute" }}
+    >
+      <defs>
+        <symbol id={RELAYER_ICON_IDS.activity} viewBox="0 0 24 24">
+          <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.plus} viewBox="0 0 24 24">
+          <path d="M5 12h14" />
+          <path d="M12 5v14" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.search} viewBox="0 0 24 24">
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.35-4.35" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.moreVertical} viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="1" />
+          <circle cx="12" cy="5" r="1" />
+          <circle cx="12" cy="19" r="1" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.refresh} viewBox="0 0 24 24">
+          <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+          <path d="M3 21v-5h5" />
+          <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+          <path d="M21 3v5h-5" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.shield} viewBox="0 0 24 24">
+          <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.68 0C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+          <path d="m9 12 2 2 4-4" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.clock} viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 6v6l4 2" />
+        </symbol>
+        <symbol id={RELAYER_ICON_IDS.signal} viewBox="0 0 24 24">
+          <path d="M2 20h.01" />
+          <path d="M7 20v-4" />
+          <path d="M12 20v-8" />
+          <path d="M17 20V8" />
+          <path d="M22 20V4" />
+        </symbol>
+      </defs>
+    </svg>
+  );
+}
+
+function RelayerIcon({
+  id,
+  size = 18,
+  className,
+}: {
+  id: string;
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <use href={`#${id}`} />
+    </svg>
+  );
+}
 
 export default function RelayersPage() {
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearch = useDebounce(searchTerm, 250);
 
   const displayedRelayers = useMemo(() => {
     const q = debouncedSearch.trim().toLowerCase();
     if (!q) return MOCK_RELAYERS;
-    return MOCK_RELAYERS.filter(r => r.name.toLowerCase().includes(q) || r.address.toLowerCase().includes(q));
+    return MOCK_RELAYERS.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) || r.address.toLowerCase().includes(q),
+    );
   }, [debouncedSearch]);
 
   // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
   const shortenedAddressMap = useMemo<Record<string, string>>(
-    () => Object.fromEntries(
-      useTransformedCustomAddressField(MOCK_RELAYERS, 'address').map(r => [r.id, r.shortenedAddress])
-    ),
-    []
+    () =>
+      Object.fromEntries(
+        useTransformedCustomAddressField(MOCK_RELAYERS, "address").map((r) => [
+          r.id,
+          r.shortenedAddress,
+        ]),
+      ),
+    [],
   );
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-gray-100 p-8">
+      <RelayerIconDefs />
       {/* --- Header Section --- */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
         <div>
           <p className="text-sm text-gray-500 mb-1">Admin / Network</p>
-          <h1 className="text-3xl font-bold tracking-tight">Relayer Management</h1>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Relayer Management
+          </h1>
         </div>
         <button className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-all font-medium">
-          <Plus size={18} />
+          <RelayerIcon id={RELAYER_ICON_IDS.plus} size={18} />
           Add New Relayer
         </button>
       </div>
 
       {/* --- Stats Row --- */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <StatCard title="Total Relayers" value="12" icon={<Activity className="text-blue-400" />} subtitle="3 Regions Active" />
-        <StatCard title="Avg Network Latency" value="45ms" icon={<Signal className="text-green-400" />} subtitle="+2ms from last hour" />
-        <StatCard title="Network Uptime" value="99.98%" icon={<ShieldCheck className="text-purple-400" />} subtitle="Last 24 hours" />
+        <StatCard
+          title="Total Relayers"
+          value="12"
+          icon={
+            <RelayerIcon
+              id={RELAYER_ICON_IDS.activity}
+              className="text-blue-400"
+            />
+          }
+          subtitle="3 Regions Active"
+        />
+        <StatCard
+          title="Avg Network Latency"
+          value="45ms"
+          icon={
+            <RelayerIcon
+              id={RELAYER_ICON_IDS.signal}
+              className="text-green-400"
+            />
+          }
+          subtitle="+2ms from last hour"
+        />
+        <StatCard
+          title="Network Uptime"
+          value="99.98%"
+          icon={
+            <RelayerIcon
+              id={RELAYER_ICON_IDS.shield}
+              className="text-purple-400"
+            />
+          }
+          subtitle="Last 24 hours"
+        />
       </div>
 
       {/* --- Table Section --- */}
       <div className="bg-[#161b22] border border-gray-800 rounded-xl overflow-hidden">
         <div className="p-4 border-b border-gray-800 flex flex-col md:flex-row justify-between gap-4">
           <div className="relative w-full md:w-96">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" size={18} />
-            <input 
-              type="text" 
-              placeholder="Search by name or address..." 
+            <RelayerIcon
+              id={RELAYER_ICON_IDS.search}
+              size={18}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
+            />
+            <input
+              type="text"
+              placeholder="Search by name or address..."
               className="w-full bg-[#0d1117] border border-gray-700 rounded-md py-2 pl-10 pr-4 text-sm focus:outline-none focus:border-blue-500 transition-colors"
               onChange={(e) => setSearchTerm(e.target.value)}
             />
           </div>
           <div className="flex gap-2">
             <button className="p-2 hover:bg-gray-800 rounded-md border border-gray-700 text-gray-400">
-              <RefreshCw size={18} />
+              <RelayerIcon id={RELAYER_ICON_IDS.refresh} size={18} />
             </button>
           </div>
         </div>
@@ -105,29 +252,43 @@ export default function RelayersPage() {
             </thead>
             <tbody className="divide-y divide-gray-800">
               {displayedRelayers.map((relayer) => (
-                <tr key={relayer.id} className="hover:bg-[#1c2128] transition-colors group">
+                <tr
+                  key={relayer.id}
+                  className="hover:bg-[#1c2128] transition-colors group"
+                >
                   <td className="px-6 py-4">
-                    <div className="font-medium text-blue-400">{relayer.name}</div>
+                    <div className="font-medium text-blue-400">
+                      {relayer.name}
+                    </div>
                     {/* PERFORMANCE OPTIMIZATION: O(1) map lookup instead of O(n) array scan */}
-                    <div className="text-xs text-gray-500 font-mono">{shortenedAddressMap[relayer.id]}</div>
+                    <div className="text-xs text-gray-500 font-mono">
+                      {shortenedAddressMap[relayer.id]}
+                    </div>
                   </td>
                   <td className="px-6 py-4">
                     <StatusBadge status={relayer.status} />
                   </td>
                   <td className="px-6 py-4 text-sm">{relayer.uptime}</td>
-                  <td className="px-6 py-4 text-sm font-mono">{relayer.latency}ms</td>
+                  <td className="px-6 py-4 text-sm font-mono">
+                    {relayer.latency}ms
+                  </td>
                   <td className="px-6 py-4">
                     <div className="w-24 bg-gray-700 h-1.5 rounded-full overflow-hidden">
-                      <div 
-                        className="bg-blue-500 h-full" 
-                        style={{ width: `${relayer.successRate}%` }} 
+                      <div
+                        className="bg-blue-500 h-full"
+                        style={{ width: `${relayer.successRate}%` }}
                       />
                     </div>
-                    <span className="text-[10px] text-gray-500 mt-1 block">{relayer.successRate}% confirmed</span>
+                    <span className="text-[10px] text-gray-500 mt-1 block">
+                      {relayer.successRate}% confirmed
+                    </span>
                   </td>
                   <td className="px-6 py-4 text-right">
                     <button className="p-1.5 hover:bg-gray-700 rounded-md text-gray-400">
-                      <MoreVertical size={18} />
+                      <RelayerIcon
+                        id={RELAYER_ICON_IDS.moreVertical}
+                        size={18}
+                      />
                     </button>
                   </td>
                 </tr>
@@ -141,14 +302,27 @@ export default function RelayersPage() {
       <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="bg-[#161b22] border border-gray-800 rounded-xl p-6">
           <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <Clock size={18} className="text-gray-400" />
+            <RelayerIcon
+              id={RELAYER_ICON_IDS.clock}
+              size={18}
+              className="text-gray-400"
+            />
             Live Feed Activity
           </h3>
           <div className="space-y-3 font-mono text-xs overflow-y-auto max-h-48">
-             <p className="text-green-500/80">[12:30:05] VTPass Lagos: Successfully pushed NGN/XLM</p>
-             <p className="text-gray-400">[12:29:45] Coinbase Global: Ping acknowledgment received (45ms)</p>
-             <p className="text-yellow-500/80">[12:28:10] Binance Pan-Africa: High latency detected (540ms)</p>
-             <p className="text-gray-400">[12:25:30] Relayer Manager: Auto-healing protocol initiated for Region: West-1</p>
+            <p className="text-green-500/80">
+              [12:30:05] VTPass Lagos: Successfully pushed NGN/XLM
+            </p>
+            <p className="text-gray-400">
+              [12:29:45] Coinbase Global: Ping acknowledgment received (45ms)
+            </p>
+            <p className="text-yellow-500/80">
+              [12:28:10] Binance Pan-Africa: High latency detected (540ms)
+            </p>
+            <p className="text-gray-400">
+              [12:25:30] Relayer Manager: Auto-healing protocol initiated for
+              Region: West-1
+            </p>
           </div>
         </div>
       </div>
@@ -158,7 +332,17 @@ export default function RelayersPage() {
 
 // --- Sub-components ---
 
-function StatCard({ title, value, icon, subtitle }: { title: string, value: string, icon: React.ReactNode, subtitle: string }) {
+function StatCard({
+  title,
+  value,
+  icon,
+  subtitle,
+}: {
+  title: string;
+  value: string;
+  icon: React.ReactNode;
+  subtitle: string;
+}) {
   return (
     <div className="bg-[#161b22] border border-gray-800 p-6 rounded-xl">
       <div className="flex justify-between items-start mb-2">
@@ -172,10 +356,14 @@ function StatCard({ title, value, icon, subtitle }: { title: string, value: stri
 }
 
 const StatusBadge = React.memo(
-  function StatusBadge({ status }: { status: 'active' | 'lagging' | 'offline' }) {
+  function StatusBadge({
+    status,
+  }: {
+    status: "active" | "lagging" | "offline";
+  }) {
     return (
       <span
-        style={{ contain: 'layout', willChange: 'opacity, transform' }}
+        style={{ contain: "layout", willChange: "opacity, transform" }}
         className={`px-2 py-1 rounded-full text-[10px] font-bold border uppercase tracking-tighter ${RELAYERS_PAGE_STATUS_VARIANTS[status]}`}
       >
         ● {status}
@@ -185,4 +373,4 @@ const StatusBadge = React.memo(
   (prev, next) => prev.status === next.status,
 );
 
-StatusBadge.displayName = 'StatusBadge';
+StatusBadge.displayName = "StatusBadge";


### PR DESCRIPTION


Pauses live stream ingestion when the browser tab is hidden and resumes when the page becomes visible again.



- Added `visibilitychange` handling to the WebSocket hook
- Unsubscribes/closes the socket while the page is hidden
- Prevents hidden-tab WebSocket message ingestion and reconnect loops
- Pauses fallback price polling while the page is hidden

Closes #159 