### PR TITLE
perf: deduplicate network health requests

### DIFF
--- a/src/app/components/SystemStats.tsx
+++ b/src/app/components/SystemStats.tsx
@@ -1,6 +1,11 @@
-import React from "react";
-import Breadcrumb from "./Breadcrumb";
+"use client";
+import React, { useEffect, useState } from "react";
 import GlobalHealthIndicator from "./GlobalHealthIndicator";
+import {
+  FALLBACK_NETWORK_HEALTH,
+  fetchNetworkHealth,
+  type NetworkHealth,
+} from "@/lib/network-health";
 
 interface StatsCardProps {
   label: string;
@@ -30,6 +35,30 @@ const StatsCard = ({ label, value, showDot = false }: StatsCardProps) => {
 };
 
 const SystemStats = () => {
+  const [networkHealth, setNetworkHealth] = useState<NetworkHealth>(
+    FALLBACK_NETWORK_HEALTH,
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    fetchNetworkHealth()
+      .then((health) => {
+        if (mounted) {
+          setNetworkHealth(health);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setNetworkHealth(FALLBACK_NETWORK_HEALTH);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
     <section className="w-full max-w-7xl mx-auto px-4 sm:px-6">
       {/* Section label */}
@@ -39,10 +68,9 @@ const SystemStats = () => {
 
       {/* Main card */}
       <div className="bg-[#0A0F1E] border border-[#1B2A3B] border-t-2 border-t-[#39FF14] rounded-lg overflow-hidden shadow-2xl">
-
         {/* Global Health row */}
         <div className="px-6 py-4">
-          <GlobalHealthIndicator status="ACTIVE" />
+          <GlobalHealthIndicator status={networkHealth.status} />
         </div>
 
         {/* Green separator */}
@@ -50,9 +78,19 @@ const SystemStats = () => {
 
         {/* Stats grid */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-4 px-6 py-8">
-          <StatsCard label="Global Health:" value="0" showDot={true} />
-          <StatsCard label="Active Contracts" value="4" />
-          <StatsCard label="Whitelisted Relayers:" value="3" />
+          <StatsCard
+            label="Global Health:"
+            value={networkHealth.globalHealth}
+            showDot={networkHealth.status === "ACTIVE"}
+          />
+          <StatsCard
+            label="Active Contracts"
+            value={networkHealth.activeContracts}
+          />
+          <StatsCard
+            label="Whitelisted Relayers:"
+            value={networkHealth.whitelistedRelayers}
+          />
         </div>
 
         {/* Bottom separator */}

--- a/src/lib/network-health.ts
+++ b/src/lib/network-health.ts
@@ -1,0 +1,54 @@
+import { requestController } from "@/lib/request-controller";
+
+export type NetworkHealthStatus = "ACTIVE" | "INACTIVE" | "WARNING";
+
+export interface NetworkHealth {
+  status: NetworkHealthStatus;
+  globalHealth: number;
+  activeContracts: number;
+  whitelistedRelayers: number;
+}
+
+const FALLBACK_NETWORK_HEALTH: NetworkHealth = {
+  status: "ACTIVE",
+  globalHealth: 0,
+  activeContracts: 4,
+  whitelistedRelayers: 3,
+};
+
+function normalizeNetworkHealth(
+  payload: Partial<NetworkHealth>,
+): NetworkHealth {
+  return {
+    status: payload.status ?? FALLBACK_NETWORK_HEALTH.status,
+    globalHealth:
+      typeof payload.globalHealth === "number"
+        ? payload.globalHealth
+        : FALLBACK_NETWORK_HEALTH.globalHealth,
+    activeContracts:
+      typeof payload.activeContracts === "number"
+        ? payload.activeContracts
+        : FALLBACK_NETWORK_HEALTH.activeContracts,
+    whitelistedRelayers:
+      typeof payload.whitelistedRelayers === "number"
+        ? payload.whitelistedRelayers
+        : FALLBACK_NETWORK_HEALTH.whitelistedRelayers,
+  };
+}
+
+export async function fetchNetworkHealth(): Promise<NetworkHealth> {
+  return requestController.dedupe("network-health", async () => {
+    const response = await fetch("/api/network-health", {
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Network health request failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as Partial<NetworkHealth>;
+    return normalizeNetworkHealth(payload);
+  });
+}
+
+export { FALLBACK_NETWORK_HEALTH };

--- a/src/lib/request-controller.ts
+++ b/src/lib/request-controller.ts
@@ -1,0 +1,31 @@
+type RequestKey = string;
+
+class RequestController {
+  private inflightRequests = new Map<RequestKey, Promise<unknown>>();
+
+  dedupe<T>(key: RequestKey, requestFn: () => Promise<T>): Promise<T> {
+    const existingRequest = this.inflightRequests.get(key);
+
+    if (existingRequest) {
+      return existingRequest as Promise<T>;
+    }
+
+    const request = requestFn().finally(() => {
+      this.inflightRequests.delete(key);
+    });
+
+    this.inflightRequests.set(key, request);
+    return request;
+  }
+
+  clear(key?: RequestKey) {
+    if (key) {
+      this.inflightRequests.delete(key);
+      return;
+    }
+
+    this.inflightRequests.clear();
+  }
+}
+
+export const requestController = new RequestController();


### PR DESCRIPTION
Adds a shared request controller to deduplicate concurrent Network Health requests.
Added global `requestController` for inflight request deduplication
 Added shared `fetchNetworkHealth` helper
 Updated `SystemStats` to fetch network health through the deduped request path
 Preserved fallback status values for unavailable health responses
Closes #108 