### PR TITLE
fix(docs): add explicit cleanup hooks for playground timeouts

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -19,16 +19,28 @@ export default function DocsPage() {
   const [invoking, setInvoking] = useState(false);
   const [invokeResult, setInvokeResult] = useState<string | null>(null);
 
+  const copyTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const invokeTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (invokeTimeoutRef.current) clearTimeout(invokeTimeoutRef.current);
+    };
+  }, []);
+
   const handleCopy = (text: string) => {
     navigator.clipboard.writeText(text);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
   };
 
   const handleTestInvoke = () => {
     setInvoking(true);
     setInvokeResult(null);
-    setTimeout(() => {
+    if (invokeTimeoutRef.current) clearTimeout(invokeTimeoutRef.current);
+    invokeTimeoutRef.current = setTimeout(() => {
       setInvoking(false);
       setInvokeResult(
         JSON.stringify({


### PR DESCRIPTION
## Fixes #155: Memory Leak Prevention on Interactive Playground Tabs

### Description
This PR resolves a memory leak issue and prevents "unmounted component" state update errors within the Developer Gateway & Docs (`src/app/docs/page.tsx`). Previously, repeatedly switching between documentation tabs or navigating away from the page while the `handleCopy` or `handleTestInvoke` timers were still running resulted in an accumulation of unmanaged listeners (timeouts). 

### Technical Changes
- **Explicit Cleanup Hooks:** Added an explicit `useEffect` cleanup hook that destroys any active timers when the module unmounts, severing pending context subscriptions.
- **Reference Tracking:** Utilized `useRef` (`copyTimeoutRef` and `invokeTimeoutRef`) to accurately track and maintain the background timers without triggering unnecessary re-renders.
- **Deduplication:** Added checks to immediately sever any currently running timeouts if a user rapidly spams the interaction buttons before triggering a new timeout.

### Verification
- Rapidly switching between the Rust/JS tabs while an action is processing no longer causes overlapping UI bugs.
- Navigating away from the `/docs` route while an RPC invocation is processing no longer throws React state update warnings in the console.


closes #155 