### PR TITLE
perf: prevent theme flash with blocking script in _document and layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,6 +37,19 @@ export default function RootLayout({
       <head>
         {/* Prevent background flash before next-themes hydrates */}
         <style>{`html { background-color: #0d1117; }`}</style>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('theme') || 'dark';
+                  document.documentElement.classList.add(theme);
+                  document.documentElement.style.colorScheme = theme;
+                } catch (e) {}
+              })()
+            `,
+          }}
+        />
         {/* Preload the critical above-the-fold logo asset */}
         <link
           rel="preload"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,29 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                (function() {
+                  try {
+                    var theme = localStorage.getItem('theme') || 'dark';
+                    document.documentElement.classList.add(theme);
+                    document.documentElement.style.colorScheme = theme;
+                  } catch (e) {}
+                })()
+              `,
+            }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}


### PR DESCRIPTION
Created src/pages/_document.tsx with a blocking script in <Head> that reads the stored theme from localStorage (defaulting to "dark") and applies the theme class to document.documentElement before page load.
Modified src/app/layout.tsx to inject the same blocking <script> element inside the <head> to prevent the white background flash on initial load and route transitions in the Next.js App Router.
Why it was done

Without this blocking script, the document element is rendered before next-themes hydrates, causing the background to default to white (from the :root styles) and create a visible white flash before the dark theme stylesheet is parsed and applied.
How it was verified

Verified syntax, file paths, and staging.
Ran npm install and npm run build (Note: The build output identified unrelated syntax/semantic errors on upstream main in FloatingSidebar.tsx and logs/page.tsx).
Closes #109 