### PR TITLE
feat: configure precise namespace imports for bundle optimization

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,7 +48,12 @@ const nextConfig: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
   experimental: {
-    optimizePackageImports: ['lucide-react'],
+    optimizePackageImports: [
+      'lucide-react',
+      'framer-motion',
+      '@tanstack/react-virtual',
+      '@tanstack/react-query',
+    ],
   },
 };
 

--- a/src/app/logs/search-worker.ts
+++ b/src/app/logs/search-worker.ts
@@ -1,4 +1,4 @@
-import Fuse from 'fuse.js';
+import Fuse from 'fuse.js/basic';
 import { LogEntry } from './types';
 
 let fuse: Fuse<LogEntry> | null = null;


### PR DESCRIPTION
Configure precise namespace imports for bundle optimization
  
  - Replaced import Fuse from 'fuse.js' with import Fuse from 'fuse.js/basic' in search-worker.ts
   to use the minimal build, excluding unused extended search operators.
  - Added framer-motion, @tanstack/react-virtual, and @tanstack/react-query to
  optimizePackageImports in next.config.ts so the Next.js compiler tree-shakes these packages to
  only the exports actually used, reducing bundle size.
closes #167