### PR TITLE
perf: add IndexedDB local cache for historical proposals, closes #248

### DIFF
--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { 
   Vote, 
   FilePlus, 
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
 import { useRAFInterval } from '@/app/hooks/useRAFInterval';
+import { useProposalCache } from '@/app/hooks/useProposalCache';
 
 // --- Types ---
 interface Proposal {
@@ -38,16 +39,33 @@ const MOCK_PROPOSALS: Proposal[] = [
 
 export default function GovernancePage() {
   const [activeTab, setActiveTab] = useState<'all' | 'active' | 'archived'>('all');
+  const [proposals, setProposals] = useState<Proposal[]>(MOCK_PROPOSALS);
+  const { saveProposals, loadProposals } = useProposalCache<Proposal>();
+  const hydrated = useRef(false);
+
+  // On mount: pull archived collections from IndexedDB cache; fall back to mock data
+  useEffect(() => {
+    if (hydrated.current) return;
+    hydrated.current = true;
+    loadProposals().then((cached) => {
+      if (cached.length > 0) {
+        setProposals(cached);
+      } else {
+        // Seed the cache with initial data on first load
+        saveProposals(MOCK_PROPOSALS).catch(console.error);
+      }
+    }).catch(console.error);
+  }, [loadProposals, saveProposals]);
 
   // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
   const transformedProposals = useMemo(
-    () => useTransformedCustomAddressField(MOCK_PROPOSALS, 'proposer'),
-    []
+    () => useTransformedCustomAddressField(proposals, 'proposer'),
+    [proposals]
   );
 
   // Live ledger countdown — one shared RAF tick every ~5 s (Stellar avg ledger time)
   const [ledgerCounts, setLedgerCounts] = useState<Record<string, number>>(
-    () => Object.fromEntries(MOCK_PROPOSALS.map(p => [p.id, p.endsInLedgers]))
+    () => Object.fromEntries(proposals.map(p => [p.id, p.endsInLedgers]))
   );
 
   useRAFInterval(() => {

--- a/src/app/hooks/useProposalCache.ts
+++ b/src/app/hooks/useProposalCache.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+const DB_NAME = 'stellarflow-governance';
+const STORE_NAME = 'proposals';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = (e) => {
+      const db = (e.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Lightweight IndexedDB sync layer for historical proposal collections.
+ * Pulls archived data from local cache on subsequent page reloads,
+ * avoiding redundant network fetches and reducing memory pressure.
+ */
+export function useProposalCache<T extends { id: string }>() {
+  const dbRef = useRef<IDBDatabase | null>(null);
+
+  useEffect(() => {
+    openDB().then((db) => { dbRef.current = db; }).catch(console.error);
+    return () => { dbRef.current?.close(); };
+  }, []);
+
+  const saveProposals = useCallback(async (proposals: T[]): Promise<void> => {
+    const db = dbRef.current ?? await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      proposals.forEach((p) => store.put(p));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }, []);
+
+  const loadProposals = useCallback(async (): Promise<T[]> => {
+    const db = dbRef.current ?? await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).getAll();
+      req.onsuccess = () => resolve(req.result as T[]);
+      req.onerror = () => reject(req.error);
+    });
+  }, []);
+
+  const clearProposals = useCallback(async (): Promise<void> => {
+    const db = dbRef.current ?? await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }, []);
+
+  return { saveProposals, loadProposals, clearProposals };
+}


### PR DESCRIPTION
perf: IndexedDB local storage cache for historical proposals

Reloading deep historical voting data on every session refresh was straining
application memory limits. This adds a lightweight IndexedDB sync layer that
persists proposal collections to the browser's local database.

Changes:
- New `useProposalCache` hook (src/app/hooks/useProposalCache.ts) — wraps
  IndexedDB with saveProposals, loadProposals, and clearProposals using a
  single persistent connection via useRef
- Governance page hydrates from IndexedDB on mount; seeds the cache on first
  visit and pulls from local storage on all subsequent reloads

Closes #248
