### PR TITLE
perf(governance): fix #236 proposal list layout shift and #239 lucide tree shaking

### DIFF
--- a/src/app/consumers/page.tsx
+++ b/src/app/consumers/page.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
-import { 
-  Users, 
-  Key, 
-  Layers, 
-  CreditCard, 
-  Plus, 
-  Search, 
-  ExternalLink, 
-  CheckCircle2, 
-  RefreshCcw, 
-  Eye, 
-  EyeOff, 
-  Copy 
-} from 'lucide-react';
-import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
+import React, { useState } from 'react';
+import Users from 'lucide-react/dist/esm/icons/users';
+import Key from 'lucide-react/dist/esm/icons/key';
+import Layers from 'lucide-react/dist/esm/icons/layers';
+import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
+import Plus from 'lucide-react/dist/esm/icons/plus';
+import Search from 'lucide-react/dist/esm/icons/search';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
+import RefreshCcw from 'lucide-react/dist/esm/icons/refresh-ccw';
+import Eye from 'lucide-react/dist/esm/icons/eye';
+import EyeOff from 'lucide-react/dist/esm/icons/eye-off';
+import Copy from 'lucide-react/dist/esm/icons/copy';
+import { withShortenedAddressField } from '@/utils/addressUtils';
 
 // --- Types ---
 interface Consumer {
@@ -36,15 +34,11 @@ const MOCK_CONSUMERS: Consumer[] = [
   { id: 'C-04', projectName: 'Test Sandbox', contractAddress: 'GDD2VHZLKMNPQRSXYZABCDEFGHIJKLM3311', tier: 'Staging', status: 'paused', monthlyRequests: '12K', balanceXLM: 0.00 },
 ];
 
+const TRANSFORMED_CONSUMERS = withShortenedAddressField(MOCK_CONSUMERS, 'contractAddress');
+
 export default function ConsumersPage() {
   const [showSecret, setShowSecret] = useState(false);
   const [copied, setCopied] = useState(false);
-
-  // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
-  const transformedConsumers = useMemo(
-    () => useTransformedCustomAddressField(MOCK_CONSUMERS, 'contractAddress'),
-    []
-  );
 
   const handleCopy = () => {
     setCopied(true);
@@ -145,7 +139,7 @@ export default function ConsumersPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-800">
-              {transformedConsumers.map((consumer) => (
+              {TRANSFORMED_CONSUMERS.map((consumer) => (
                 <tr key={consumer.id} className="hover:bg-[#1c2128] transition-colors group">
                   <td className="px-6 py-4">
                     <div className="font-medium text-gray-200">{consumer.projectName}</div>

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -1,18 +1,15 @@
 "use client";
 
 import React, { useState } from 'react';
-import { 
-  Cpu, 
-  Upload, 
-  ShieldAlert, 
-  Zap, 
-  Lock, 
-  Unlock, 
-  History, 
-  Code2, 
-  CheckCircle2, 
-  AlertTriangle 
-} from 'lucide-react';
+import Upload from 'lucide-react/dist/esm/icons/upload';
+import ShieldAlert from 'lucide-react/dist/esm/icons/shield-alert';
+import Zap from 'lucide-react/dist/esm/icons/zap';
+import Lock from 'lucide-react/dist/esm/icons/lock';
+import Unlock from 'lucide-react/dist/esm/icons/unlock';
+import History from 'lucide-react/dist/esm/icons/history';
+import Code2 from 'lucide-react/dist/esm/icons/code-2';
+import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import { CONTRACT_HEALTH_ICON_VARIANTS } from '@/lib/classNameVariants';
 
 export default function ContractsPage() {

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
-import { 
-  Vote, 
-  FilePlus, 
-  CheckCircle, 
-  XCircle, 
-  Clock, 
-  Users, 
-  Search, 
-  RefreshCw, 
-  ChevronRight, 
-  Wallet 
-} from 'lucide-react';
-import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
+import React, { useMemo, useState } from 'react';
+import Vote from 'lucide-react/dist/esm/icons/vote';
+import FilePlus from 'lucide-react/dist/esm/icons/file-plus';
+import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
+import Clock from 'lucide-react/dist/esm/icons/clock';
+import Users from 'lucide-react/dist/esm/icons/users';
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
+import Wallet from 'lucide-react/dist/esm/icons/wallet';
+import { withShortenedAddressField } from '@/utils/addressUtils';
 import { useRAFInterval } from '@/app/hooks/useRAFInterval';
 
 // --- Types ---
@@ -36,13 +31,31 @@ const MOCK_PROPOSALS: Proposal[] = [
   { id: 'SFP-09', title: 'Increase Relayer Missed-Heartbeat Penalty Weight by 2%', proposer: 'GCXXVHZLKMNPQRSXYZABCDEFGHIJKLM7766', status: 'Defeated', votesFor: 110000, votesAgainst: 920000, quorumThreshold: 50, endsInLedgers: 0 },
 ];
 
+const TRANSFORMED_PROPOSALS = withShortenedAddressField(MOCK_PROPOSALS, 'proposer');
+/** Pre-allocated stack for full mock set (4 × card height + gaps) — stable before filter/async hydration */
+const PROPOSAL_LIST_SURFACE_CLASSES = 'space-y-4 min-h-[800px] md:min-h-[720px] lg:min-h-[672px]';
+const PROPOSAL_CARD_SURFACE_CLASSES = 'h-[188px] md:h-[168px] lg:h-[156px] overflow-hidden';
+const PROPOSAL_LEDGER_SLOT_CLASSES = 'h-5 min-w-[220px] flex items-center gap-1 text-xs text-gray-500 font-mono tabular-nums';
+
+function filterProposalsByTab<T extends { status: Proposal['status'] }>(
+  proposals: T[],
+  tab: 'all' | 'active' | 'archived',
+): T[] {
+  if (tab === 'active') {
+    return proposals.filter((p) => p.status === 'Active');
+  }
+  if (tab === 'archived') {
+    return proposals.filter((p) => p.status !== 'Active');
+  }
+  return proposals;
+}
+
 export default function GovernancePage() {
   const [activeTab, setActiveTab] = useState<'all' | 'active' | 'archived'>('all');
 
-  // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
-  const transformedProposals = useMemo(
-    () => useTransformedCustomAddressField(MOCK_PROPOSALS, 'proposer'),
-    []
+  const visibleProposals = useMemo(
+    () => filterProposalsByTab(TRANSFORMED_PROPOSALS, activeTab),
+    [activeTab],
   );
 
   // Live ledger countdown — one shared RAF tick every ~5 s (Stellar avg ledger time)
@@ -97,14 +110,14 @@ export default function GovernancePage() {
       </div>
 
       {/* --- Proposal List Suite --- */}
-      <div className="space-y-4">
-        {transformedProposals.map((proposal) => {
+      <div className={PROPOSAL_LIST_SURFACE_CLASSES}>
+        {visibleProposals.map((proposal) => {
           const totalVotes = proposal.votesFor + proposal.votesAgainst;
           const forPercentage = totalVotes > 0 ? (proposal.votesFor / totalVotes) * 100 : 0;
           
           return (
-            <div key={proposal.id} className="bg-[#161b22] border border-gray-800 rounded-xl p-6 hover:border-gray-700 transition-colors group">
-              <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+            <div key={proposal.id} className={`${PROPOSAL_CARD_SURFACE_CLASSES} bg-[#161b22] border border-gray-800 rounded-xl p-6 hover:border-gray-700 transition-colors group`}>
+              <div className="flex min-h-full flex-col lg:flex-row lg:items-center justify-between gap-4">
                 
                 {/* Proposal Text Meta */}
                 <div className="space-y-2 max-w-2xl">
@@ -117,11 +130,13 @@ export default function GovernancePage() {
                     }`}>
                       {proposal.status}
                     </span>
-                    {proposal.status === 'Active' && (
-                      <span className="text-xs text-gray-500 flex items-center gap-1 font-mono">
-                        <Clock size={12} /> ~{(ledgerCounts[proposal.id] ?? 0).toLocaleString()} ledgers remaining
-                      </span>
-                    )}
+                    <span
+                      className={`${PROPOSAL_LEDGER_SLOT_CLASSES} ${proposal.status === 'Active' ? '' : 'invisible'}`}
+                      aria-hidden={proposal.status !== 'Active'}
+                    >
+                      <Clock size={12} className="shrink-0" />
+                      ~{(ledgerCounts[proposal.id] ?? 0).toLocaleString()} ledgers remaining
+                    </span>
                   </div>
                   <h3 className="text-lg font-semibold text-gray-100 group-hover:text-blue-400 transition-colors">{proposal.title}</h3>
                   {/* PERFORMANCE OPTIMIZATION: Use pre-computed shortened address instead of runtime string slicing */}

--- a/src/app/staking/page.tsx
+++ b/src/app/staking/page.tsx
@@ -2,19 +2,17 @@
 
 import React, { useState, useMemo } from 'react';
 import { useDebounce } from '../hooks/useDebounce';
-import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
-import { 
-  ShieldCheck, 
-  Coins, 
-  Percent, 
-  Flame, 
-  Search, 
-  RefreshCw, 
-  AlertTriangle, 
-  Gavel, 
-  TrendingUp, 
-  ArrowUpRight 
-} from 'lucide-react';
+import { withShortenedAddressField } from '@/utils/addressUtils';
+import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
+import Coins from 'lucide-react/dist/esm/icons/coins';
+import Percent from 'lucide-react/dist/esm/icons/percent';
+import Flame from 'lucide-react/dist/esm/icons/flame';
+import Search from 'lucide-react/dist/esm/icons/search';
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import Gavel from 'lucide-react/dist/esm/icons/gavel';
+import TrendingUp from 'lucide-react/dist/esm/icons/trending-up';
+import ArrowUpRight from 'lucide-react/dist/esm/icons/arrow-up-right';
 import {
   getHealthBarColor,
   STAKER_SLASHING_NO_EVENTS,
@@ -40,6 +38,13 @@ const MOCK_STAKERS: StakerNode[] = [
   { id: 'N-404', nodeName: 'Accra Frontier Oracle', operatorAddress: 'GCXXVHZLKMNPQRSXYZABCDEFGHIJKLM7766', stakedAmountXLM: 25000.00, accruedRewardsXLM: 310.20, totalSlashingEvents: 3, healthFactor: 62 },
 ];
 
+const SHORTENED_STAKER_ADDRESS_MAP = Object.fromEntries(
+  withShortenedAddressField(MOCK_STAKERS, 'operatorAddress').map((staker) => [
+    staker.id,
+    staker.shortenedAddress,
+  ]),
+);
+
 export default function StakingPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearch = useDebounce(searchTerm, 250);
@@ -49,14 +54,6 @@ export default function StakingPage() {
     if (!q) return MOCK_STAKERS;
     return MOCK_STAKERS.filter(s => s.nodeName.toLowerCase().includes(q) || s.operatorAddress.toLowerCase().includes(q));
   }, [debouncedSearch]);
-
-  // Pre-compute shortened addresses on data ingestion to avoid render-time string slicing
-  const shortenedAddressMap = useMemo<Record<string, string>>(
-    () => Object.fromEntries(
-      useTransformedCustomAddressField(MOCK_STAKERS, 'operatorAddress').map(s => [s.id, s.shortenedAddress])
-    ),
-    []
-  );
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-gray-100 p-8">
@@ -122,7 +119,7 @@ export default function StakingPage() {
                   <td className="px-6 py-4">
                     <div className="font-medium text-gray-200">{node.nodeName}</div>
                     {/* PERFORMANCE OPTIMIZATION: O(1) map lookup instead of O(n) array scan */}
-                    <div className="text-xs text-gray-500 font-mono">{shortenedAddressMap[node.id]}</div>
+                    <div className="text-xs text-gray-500 font-mono">{SHORTENED_STAKER_ADDRESS_MAP[node.id]}</div>
                   </td>
                   <td className="px-6 py-4 text-sm font-mono text-gray-300">
                     {node.stakedAmountXLM.toLocaleString()} XLM


### PR DESCRIPTION
Closes #236 
Closes #239 

## PR Description

This PR closes frontend performance work for **#236** and **#239** on the four admin feature pages (governance, contracts, staking, consumers).

**#236 — Eliminating layout shift on active proposal lists**  
Governance proposal cards previously risked cumulative layout shift when addresses were shortened during render, when active ballots showed a ledger countdown row that archived ballots did not, and when tab filters changed visible items without a reserved list surface. The list now pre-allocates vertical space for the full proposal stack, uses fixed card heights with overflow clipping, pre-computes shortened proposer addresses at module load, reserves a ledger countdown slot on every card (hidden when not active), and filters proposals by tab via `useMemo` while keeping the outer list container height stable.

**#239 — Streamlining Lucide icon imports via tree shaking**  
The four pages no longer import from the `lucide-react` barrel. Each icon is pulled from `lucide-react/dist/esm/icons/<name>`, and unused icons were removed from governance and contracts so production bundles do not retain dead icon modules.

**Why it matters:** Reviewers and users on the governance flow see stable card geometry during hydration and live ledger ticks, and production builds avoid pulling the full Lucide namespace on these high-traffic admin routes.

**Scope:** Frontend-only. No backend, contract, or env changes.

## Changed

- **#236** — `src/app/governance/page.tsx`: module-level `TRANSFORMED_PROPOSALS`, fixed list/card dimensions, reserved ledger slot, tab filtering with stable list surface
- **#239** — `src/app/governance/page.tsx`: direct Lucide ESM icon imports; removed unused barrel icons
- **#239** — `src/app/contracts/page.tsx`: direct Lucide ESM icon imports
- **#239** — `src/app/staking/page.tsx`: direct Lucide ESM icon imports
- **#239** — `src/app/consumers/page.tsx`: direct Lucide ESM icon imports