### PR TITLE
Cleaning Up Inactive Event Listeners on Unmount

### DIFF
--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -22,16 +22,21 @@ function Map() {
   const { error, setError } = useErrorTimeout({ timeoutMs: 5000 });
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     const loadMapData = async () => {
       try {
         // Load the simplified Africa network data
-        const response = await fetch("/africa-network-simplified.geojson");
+        const response = await fetch("/africa-network-simplified.geojson", {
+          signal: abortController.signal
+        });
         if (!response.ok) {
           throw new Error(`Failed to load map data: ${response.status}`);
         }
         const data = await response.json();
         setGeoData(data);
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
         setError(err instanceof Error ? err.message : "Unknown error");
       } finally {
         setLoading(false);
@@ -39,6 +44,10 @@ function Map() {
     };
 
     loadMapData();
+
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   // Custom style for network regions

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -35,9 +35,10 @@ interface PriceFeedCardProps {
  * Fetches the NGN/XLM price feed from the StellarFlow oracle API.
  * Adjust the endpoint URL to match your actual backend.
  */
-async function fetchNgnXlmFeed(): Promise<PriceFeedData> {
+async function fetchNgnXlmFeed(signal?: AbortSignal): Promise<PriceFeedData> {
   const res = await fetch("/api/price-feed/ngn-xlm", {
     cache: "no-store",
+    signal,
   });
 
   if (!res.ok) {
@@ -113,8 +114,16 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   const { isConnected, error: wsError } = useSocketConnection();
   const { lastUpdate: wsUpdate } = useSocketData();
 
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   const load = useCallback(
     async (manual = false) => {
+      // Cancel any in-flight requests before starting a new one
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      abortControllerRef.current = new AbortController();
+
       if (manual) {
         setIsRefreshing(true);
         start();
@@ -122,10 +131,14 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
       setError(null);
 
       try {
-        const feed = await fetchNgnXlmFeed();
+        const feed = await fetchNgnXlmFeed(abortControllerRef.current.signal);
         setData(feed);
         setLastRefresh(new Date());
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          // Ignore planned aborts
+          return;
+        }
         setError(
           err instanceof Error ? err.message : "Failed to load price feed.",
         );
@@ -135,8 +148,17 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
         if (manual) done();
       }
     },
-    [start, done],
+    [start, done, setError],
   );
+
+  // Cleanup in-flight requests on unmount
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
 
   // Merge WebSocket delta updates into local state.
   // Using a functional setData updater means we read `prev` (current state)

--- a/src/app/components/providers/UserProvider.tsx
+++ b/src/app/components/providers/UserProvider.tsx
@@ -23,13 +23,17 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     // Fetching user validation details once at the root level
     // This prevents redundant network requests across independent dashboard modules
     const fetchUserValidation = async () => {
       setIsLoading(true);
       try {
         // Attempting to fetch validation details
-        const res = await fetch("/api/user/validation").catch(() => null);
+        const res = await fetch("/api/user/validation", {
+          signal: abortController.signal
+        }).catch(() => null);
         
         if (res && res.ok) {
            const data = await res.json();
@@ -44,6 +48,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
            });
         }
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
         setError(err instanceof Error ? err.message : "Failed to fetch user validation");
       } finally {
         setIsLoading(false);
@@ -51,6 +56,10 @@ export function UserProvider({ children }: { children: ReactNode }) {
     };
 
     fetchUserValidation();
+
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   return (

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { 
   Vote, 
   FilePlus, 
@@ -50,7 +50,7 @@ export default function GovernancePage() {
     () => Object.fromEntries(MOCK_PROPOSALS.map(p => [p.id, p.endsInLedgers]))
   );
 
-  useRAFInterval(() => {
+  const updateLedgerCounts = useCallback(() => {
     setLedgerCounts(prev => {
       const next = { ...prev };
       for (const id in next) {
@@ -58,7 +58,9 @@ export default function GovernancePage() {
       }
       return next;
     });
-  }, 5000);
+  }, []);
+
+  useRAFInterval(updateLedgerCounts, 5000);
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-gray-100 p-8">

--- a/src/app/hooks/useRAFInterval.ts
+++ b/src/app/hooks/useRAFInterval.ts
@@ -24,6 +24,7 @@ export function useRAFInterval(
   const callbackRef = useRef(callback)
   const rafRef = useRef<number | null>(null)
   const lastTickRef = useRef<number | null>(null)
+  const isMountedRef = useRef(true)
 
   // Keep callback ref current without restarting the loop
   useEffect(() => {
@@ -32,6 +33,9 @@ export function useRAFInterval(
 
   const tick = useCallback(
     (now: number) => {
+      // If we unmounted, stop scheduling and stop execution
+      if (!isMountedRef.current) return
+
       if (lastTickRef.current === null) lastTickRef.current = now
 
       if (now - lastTickRef.current >= intervalMs) {
@@ -39,18 +43,23 @@ export function useRAFInterval(
         callbackRef.current()
       }
 
-      rafRef.current = requestAnimationFrame(tick)
+      // Re-verify mount state before next schedule in case callback caused unmount
+      if (isMountedRef.current) {
+        rafRef.current = requestAnimationFrame(tick)
+      }
     },
     [intervalMs],
   )
 
   useEffect(() => {
+    isMountedRef.current = true
     if (!enabled) return
 
     lastTickRef.current = null
     rafRef.current = requestAnimationFrame(tick)
 
     return () => {
+      isMountedRef.current = false
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current)
         rafRef.current = null


### PR DESCRIPTION
Use explicit return cleanup operations inside all local useEffect layout scripts to terminate connections.

Ensure background fetch handles are cleanly disposed of as routes change.

If you find this implementation useful, please star the project and leave a review! 😊


Closes #242