### PR TITLE
fix: global React Query cache for validator metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { ProgressBarProvider } from "./components/TopLoadingBar";
 import { UserProvider } from "./components/providers/UserProvider";
+import { QueryProvider } from "./components/providers/QueryProvider";
 import Script from "next/script";
 import {SocketProvider} from "./components/providers/SocketProvider";
 
@@ -72,9 +73,11 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <UserProvider>
-            <ProgressBarProvider>
-              {children}
-            </ProgressBarProvider>
+            <QueryProvider>
+              <ProgressBarProvider>
+                {children}
+              </ProgressBarProvider>
+            </QueryProvider>
           </UserProvider>
         </ThemeProvider>
       </body>

--- a/src/app/lib/queryClient.ts
+++ b/src/app/lib/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient } from '@tanstack/react-query'
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30 * 1000,          // 30s → data considered fresh
+      staleTime: 15 * 1000,          // 15s → data considered fresh
       gcTime: 5 * 60 * 1000,         // cache persists 5 mins
       refetchOnWindowFocus: false,   // 🔥 your requirement
       refetchOnReconnect: true,


### PR DESCRIPTION
Fix #234 by wrapping the root layout in the existing QueryProvider and tightening query staleTime to 15 seconds to reuse validator metadata across navigations.