### PR TITLE
Feature/prefetch assets

### DIFF
--- a/src/app/components/FloatingSidebar.tsx
+++ b/src/app/components/FloatingSidebar.tsx
@@ -46,14 +46,7 @@ const FloatingSidebar = memo(() => {
       console.debug('Prefetch failed for', href, err);
     }
   }, [router]);
-  const handlePrefetch = useCallback(
-    (href: string) => {
-      if (href === "/contracts") {
-        router.prefetch("/contracts");
-      }
-    },
-    [router],
-  );
+
 
   return (
     <nav

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -77,12 +77,11 @@ const Nav = memo(() => {
             prefetch={false}
             onFocus={() => router.prefetch('/admin/settings')}
             onMouseEnter={() => {
-              if (pathname !== '/admin/settings') router.prefetch('/admin/settings')
+              if (pathname !== '/admin/settings') router.prefetch('/admin/settings');
             }}
             onPointerEnter={() => {
-              if (pathname !== '/admin/settings') router.prefetch('/admin/settings')
+              if (pathname !== '/admin/settings') router.prefetch('/admin/settings');
             }}
-            onMouseEnter={() => router.prefetch("/admin/settings")}
             aria-label="Admin settings"
             className="p-2 rounded-xl hover:bg-zinc-800 transition-colors"
           >

--- a/src/app/components/server/Sidebar.tsx
+++ b/src/app/components/server/Sidebar.tsx
@@ -1,15 +1,17 @@
-import Link from 'next/link'
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function Sidebar() {
+  const router = useRouter();
   return (
     <aside className="w-64 h-screen bg-gray-900 text-white p-4">
       <h2 className="text-xl font-bold mb-6">Dashboard</h2>
 
       <nav className="space-y-4">
-        <Link href="/">Home</Link>
-        <Link href="/analytics">Analytics</Link>
-        <Link href="/transactions">Transactions</Link>
-        <Link href="/settings">Settings</Link>
+        <Link href="/" prefetch={false} onMouseEnter={() => router.prefetch('/')}>Home</Link>
+        <Link href="/analytics" prefetch={false} onMouseEnter={() => router.prefetch('/analytics')}>Analytics</Link>
+        <Link href="/transactions" prefetch={false} onMouseEnter={() => router.prefetch('/transactions')}>Transactions</Link>
+        <Link href="/settings" prefetch={false} onMouseEnter={() => router.prefetch('/settings')}>Settings</Link>
       </nav>
     </aside>
   )


### PR DESCRIPTION
this pr closes #244 Title: Perf | Preloading Asset Paths via Viewport Hover Interceptors
Summary
Transitioning to advanced sub-pages (such as /app/docs) felt sluggish because Next.js compilation/downloading of heavy layouts did not start until the link was clicked. This PR adds hover-based prefetching configuration to the main navigation menu components so that assets begin loading the moment a user hovers over a link, greatly improving transition latency.