### PR TITLE
fix: add axes property to Geist and Geist_Mono font configurations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
   display: "swap",
+  axes: ["wght"],
   weight: ["400", "700"]
 });
 
@@ -20,6 +21,7 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
   display: "swap",
+  axes: ["wght"],
   weight: ["400", "700"]
 });
 


### PR DESCRIPTION
## Summary

Adds variable font axis sub-setting to restrict font payload to only the needed `wght` axis, reducing downloaded font bytes by excluding unused variation axes.

## Changes

### `src/app/layout.tsx`

Added `axes: ["wght"]` to both `Geist` and `Geist_Mono` `next/font/google` configurations. This explicitly declares that only the weight axis is required, preventing any other variable font axes from being included in the downloaded WOFF2 file.

**Before:**
```ts
const geistSans = Geist({
  variable: "--font-geist-sans",
  subsets: ["latin"],
  display: "swap",
  weight: ["400", "700"]
});
```

**After:**
```ts
const geistSans = Geist({
  variable: "--font-geist-sans",
  subsets: ["latin"],
  display: "swap",
  axes: ["wght"],
  weight: ["400", "700"]
});
```

Same change applied to `Geist_Mono`.

## Rationale

- `subsets: ["latin"]` strips non-Latin character data (cyrillic, vietnamese, etc.)
- `weight: ["400", "700"]` restricts the weight range
- `axes: ["wght"]` ensures no other variation axes are loaded — this completes the variable font sub-setting pattern for `next/font/google`
- `display: "swap"` prevents invisible text during load

Closes #278 
