### PR TITLE
Ws buffer 300ms

### DIFF
--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -261,33 +261,32 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-   }, [connect]);
-
-   // Periodic flush of buffered WebSocket messages every 300ms
-   useEffect(() => {
-     const interval = setInterval(() => {
-       if (bufferRef.current.length > 0) {
-         bufferRef.current.forEach((message) => {
-           if (message.type === "price_update" || message.type === "delta_update") {
-             if (message.type === "delta_update" && message.assetId) {
-               setLastUpdate((prev: PriceData | null) =>
-                 prev
-                   ? { ...prev, ...(message.data as PriceData) }
-                   : (message.data as PriceData)
-               );
-             } else {
-               setLastUpdate(message.data as PriceData);
-             }
-           }
-         });
-         // Clear buffer after processing
-         bufferRef.current = [];
-       }
-     }, 300);
-     return () => clearInterval(interval);
-   }, []);
     };
   }, [connect]);
+
+  // Periodic flush of buffered WebSocket messages every 300ms
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (bufferRef.current.length > 0) {
+        bufferRef.current.forEach((message) => {
+          if (message.type === "price_update" || message.type === "delta_update") {
+            if (message.type === "delta_update" && message.assetId) {
+              setLastUpdate((prev: PriceData | null) =>
+                prev
+                  ? { ...prev, ...(message.data as PriceData) }
+                  : (message.data as PriceData),
+              );
+            } else {
+              setLastUpdate(message.data as PriceData);
+            }
+          }
+        });
+        // Clear buffer after processing
+        bufferRef.current = [];
+      }
+    }, 300);
+    return () => clearInterval(interval);
+  }, []);
   return {
     isConnected,
     lastUpdate,

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -55,6 +55,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
   const manuallyDisconnectedRef = useRef(false);
   const pageVisibleRef = useRef(true);
+  // Buffer for incoming WebSocket messages to batch updates
+  const bufferRef = useRef<SocketMessage[]>([]);
 
   // Refs keep options fresh inside callbacks without triggering re-renders or
   // causing `connect` to be recreated on every tick.
@@ -114,23 +116,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
         try {
           const message: SocketMessage = JSON.parse(event.data as string);
-
-          if (
-            message.type === "price_update" ||
-            message.type === "delta_update"
-          ) {
-            if (message.type === "delta_update" && message.assetId) {
-              // Functional updater — reads current state without it becoming a
-              // dependency of this callback.
-              setLastUpdate((prev: PriceData | null) =>
-                prev
-                  ? { ...prev, ...(message.data as PriceData) }
-                  : (message.data as PriceData),
-              );
-            } else {
-              setLastUpdate(message.data as PriceData);
-            }
-          }
+          // Push incoming messages to buffer for batched processing
+          bufferRef.current.push(message);
         } catch (err) {
           console.error("Failed to parse WebSocket message:", err);
         }
@@ -274,6 +261,31 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+   }, [connect]);
+
+   // Periodic flush of buffered WebSocket messages every 300ms
+   useEffect(() => {
+     const interval = setInterval(() => {
+       if (bufferRef.current.length > 0) {
+         bufferRef.current.forEach((message) => {
+           if (message.type === "price_update" || message.type === "delta_update") {
+             if (message.type === "delta_update" && message.assetId) {
+               setLastUpdate((prev: PriceData | null) =>
+                 prev
+                   ? { ...prev, ...(message.data as PriceData) }
+                   : (message.data as PriceData)
+               );
+             } else {
+               setLastUpdate(message.data as PriceData);
+             }
+           }
+         });
+         // Clear buffer after processing
+         bufferRef.current = [];
+       }
+     }, 300);
+     return () => clearInterval(interval);
+   }, []);
     };
   }, [connect]);
   return {


### PR DESCRIPTION
This PR closes #270 
Description

Implements a 300ms intermediate buffering layer for WebSocket messages to batch UI state updates. This resolves the Stream-Backpressure issue by preventing UI layout freezing during high-velocity on-chain log updates.

Technical Changes
- **WebSocket Buffer Ingestion**: Added a mutable `bufferRef` in `useSocket.ts` to collect raw message payloads.
- **300ms Interval Flush**: Set up a recurring 300ms interval loop inside the socket hook to apply all queued updates to state in a single controlled batch update, then empty the buffer.
- **Hook Cleanliness**: Refactored existing visibility change and socket initialization effect code blocks to fix bracket misalignment and guarantee parse/compilation safety.

 Verification
- Local checks confirm updates are batched and flushed at 300ms intervals.
- The UI remains completely responsive during rapid update bursts.