### PR TITLE
fix: consolidate all interval countdown operations into a single shar…

### DIFF
--- a/src/app/hooks/useRAFInterval.ts
+++ b/src/app/hooks/useRAFInterval.ts
@@ -1,60 +1,70 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef } from 'react'
 
-/**
- * Drop-in replacement for setInterval backed by a single requestAnimationFrame loop.
- *
- * All active consumers share one rAF tick; the callback fires only when the
- * elapsed wall-clock time exceeds `intervalMs`, keeping CPU usage minimal and
- * avoiding timer drift across governance ballot countdowns.
- *
- * @param callback - Stable function to invoke on each interval tick.
- * @param intervalMs - Desired interval in milliseconds (default 1000).
- * @param enabled - Set to false to pause without unmounting (default true).
- *
- * @example
- * useRAFInterval(() => setCount(c => c - 1), 1000)
- */
+type Subscriber = {
+  callback: () => void
+  intervalMs: number
+  lastTick: number
+}
+
+let rafId: number | null = null
+const subscribers = new Set<Subscriber>()
+
+const tick = (now: number) => {
+  subscribers.forEach((sub) => {
+    if (now - sub.lastTick >= sub.intervalMs) {
+      sub.lastTick = now
+      sub.callback()
+    }
+  })
+  rafId = requestAnimationFrame(tick)
+}
+
+const startLoop = () => {
+  if (rafId === null) {
+    rafId = requestAnimationFrame(tick)
+  }
+}
+
+const stopLoop = () => {
+  if (subscribers.size === 0 && rafId !== null) {
+    cancelAnimationFrame(rafId)
+    rafId = null
+  }
+}
+
 export function useRAFInterval(
   callback: () => void,
   intervalMs = 1000,
   enabled = true,
 ): void {
   const callbackRef = useRef(callback)
-  const rafRef = useRef<number | null>(null)
-  const lastTickRef = useRef<number | null>(null)
+  const subscriberRef = useRef<Subscriber | null>(null)
 
-  // Keep callback ref current without restarting the loop
   useEffect(() => {
     callbackRef.current = callback
   }, [callback])
 
-  const tick = useCallback(
-    (now: number) => {
-      if (lastTickRef.current === null) lastTickRef.current = now
-
-      if (now - lastTickRef.current >= intervalMs) {
-        lastTickRef.current = now
-        callbackRef.current()
-      }
-
-      rafRef.current = requestAnimationFrame(tick)
-    },
-    [intervalMs],
-  )
-
   useEffect(() => {
     if (!enabled) return
 
-    lastTickRef.current = null
-    rafRef.current = requestAnimationFrame(tick)
+    const subscriber: Subscriber = {
+      callback: () => callbackRef.current(),
+      intervalMs,
+      lastTick: performance.now(),
+    }
+
+    subscriberRef.current = subscriber
+    subscribers.add(subscriber)
+    startLoop()
 
     return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current)
-        rafRef.current = null
+      if (subscriberRef.current) {
+        subscribers.delete(subscriberRef.current)
+        subscriberRef.current = null
+        stopLoop()
       }
     }
-  }, [enabled, tick])
+  }, [intervalMs, enabled])
 }


### PR DESCRIPTION
- Refactored useRAFInterval Hook : Modified src/app/hooks/useRAFInterval.ts to use a single shared requestAnimationFrame loop with subscriber management instead of creating a separate RAF for every instance.
- Created a Branch : Created and switched to fix/consolidate-raf-interval .
- Committed Changes : Committed the refactor with a descriptive commit message: "fix: consolidate all interval countdown operations into a single shared requestAnimationFrame loop".

closes #322 