### PR TITLE
#324 🛡️ Strict-Hydration | Safe Server Skeleton Mappings for Cryptogr…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,12 @@
 import type { NextConfig } from "next";
 import withBundleAnalyzer from "@next/bundle-analyzer";
+import withPWA from "next-pwa";
 
 const withBundleAnalyzerConfig = withBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
-// 1. Initialize the Bundle Analyzer plugin
-const withBundleAnalyzer = require("@next/bundle-analyzer")({
-  enabled: process.env.ANALYZE === "true",
-});
-
-// 2. Initialize the PWA plugin with its production-ready caching rules
-const withPWA = require("next-pwa")({
+const withPwaConfig = withPWA({
   dest: "public",
   register: true,
   skipWaiting: true,
@@ -24,7 +19,7 @@ const withPWA = require("next-pwa")({
         cacheName: "page-shells",
         expiration: {
           maxEntries: 50,
-          maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+          maxAgeSeconds: 30 * 24 * 60 * 60,
         },
       },
     },
@@ -35,7 +30,7 @@ const withPWA = require("next-pwa")({
         cacheName: "offlineCache",
         expiration: {
           maxEntries: 200,
-          maxAgeSeconds: 24 * 60 * 60, // 24 hours
+          maxAgeSeconds: 24 * 60 * 60,
         },
         networkTimeoutSeconds: 10,
       },
@@ -43,30 +38,19 @@ const withPWA = require("next-pwa")({
   ],
 });
 
-// 3. Your optimized Next.js base configurations
 const nextConfig: NextConfig = {
   reactCompiler: false,
-  swcMinify: true,
   compress: true,
   productionBrowserSourceMaps: false,
-  optimizeFonts: true,
-  optimizePackageImports: [
-    "lucide-react",
-    "react-icons",
-  ],
-};
-
-export default withBundleAnalyzerConfig(nextConfig);
   turbopack: {},
   images: {
-    formats: ['image/avif', 'image/webp'],
+    formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
   experimental: {
-    optimizePackageImports: ['lucide-react'],
+    optimizePackageImports: ["lucide-react", "react-icons"],
   },
 };
 
-// 4. Chain both plugins together sequentially to export the final configuration
-export default withPWA(withBundleAnalyzer(nextConfig));
+export default withBundleAnalyzerConfig(withPwaConfig(nextConfig));

--- a/src/app/DashboardInteractive.tsx
+++ b/src/app/DashboardInteractive.tsx
@@ -3,7 +3,14 @@
 import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
-import { Shimmer, MapSkeleton, RateSparklineSkeleton } from "@/components/skeletons";
+import {
+  Shimmer,
+  MapSkeleton,
+  RateSparklineSkeleton,
+  PriceFeedCardSkeleton,
+  DashboardTrafficChartSkeleton,
+} from "@/components/skeletons";
+import { useMounted } from "@/app/hooks/useMounted";
 import WebSocketTest from "./components/test/WebSocketTest";
 
 const LiveNetworkMap = dynamic(() => import("@/app/components/Map"), {
@@ -21,18 +28,14 @@ const RateSparklineCard = dynamic(
 
 const PriceFeedCard = dynamic(() => import("./components/PriceFeedCard"), {
   ssr: false,
-  loading: () => (
-    <div className="h-full w-full rounded-[28px] border border-[#A7C957]/30 bg-[#0B1324] p-6 shadow-[0_24px_80px_rgba(2,8,23,0.6)]">
-      <Shimmer className="h-full w-full rounded-2xl" />
-    </div>
-  ),
+  loading: () => <PriceFeedCardSkeleton />,
 });
 
 const DashboardTrafficChart = dynamic(
   () => import("./components/DashboardTrafficChart"),
   {
     ssr: false,
-    loading: () => <MapSkeleton />,
+    loading: () => <DashboardTrafficChartSkeleton />,
   },
 );
 
@@ -43,17 +46,99 @@ interface RateCard {
   sparklineData: number[];
 }
 
+function DashboardSkeleton() {
+  return (
+    <>
+      <section className="min-w-0 grid grid-cols-1 sm:grid-cols-3 gap-6" aria-busy="true">
+        <RateSparklineSkeleton />
+        <RateSparklineSkeleton />
+        <RateSparklineSkeleton />
+      </section>
+
+      <section className="min-w-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="min-w-0 w-full max-w-full aspect-auto sm:aspect-4/3 min-h-[260px] sm:min-h-[320px] overflow-hidden">
+          <div className="flex h-full min-h-[320px] flex-col rounded-[28px] border border-[#A7C957]/30 bg-[#0A121E] p-6 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+            <div className="mb-4 space-y-2">
+              <Shimmer className="h-3 w-24 rounded-md" />
+              <Shimmer className="h-8 w-44 rounded-md" />
+            </div>
+            <Shimmer className="h-full w-full rounded-[24px]" />
+          </div>
+        </div>
+      </section>
+
+      <section className="min-w-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="min-w-0 w-full max-w-full aspect-auto sm:aspect-4/3 min-h-[260px] sm:min-h-[320px] overflow-hidden">
+          <PriceFeedCardSkeleton />
+        </div>
+      </section>
+
+      <section
+        className="content-visibility-auto space-y-4"
+        style={{ "--content-visibility-fallback": "1px 520px" } as React.CSSProperties}
+      >
+        <h2 className="text-xl font-semibold text-white uppercase tracking-wider mb-4">
+          Live Network Map
+        </h2>
+        <MapSkeleton />
+      </section>
+
+      <section
+        className="content-visibility-auto grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]"
+        style={{ "--content-visibility-fallback": "1px 620px" } as React.CSSProperties}
+      >
+        <DashboardTrafficChartSkeleton />
+
+        <div className="rounded-[32px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+          <div className="mb-5 border-b border-white/10 pb-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-[#D9F99D]/85">
+              Raw source data
+            </p>
+            <h3 className="mt-1 text-xl font-semibold text-white">
+              Incoming oracle table
+            </h3>
+          </div>
+
+          <div className="space-y-3 rounded-[24px] border border-white/8 bg-[#0F172A] p-4">
+            <div className="flex items-center justify-between text-sm text-slate-300">
+              <span>Provider feed</span>
+              <span>Status</span>
+            </div>
+            <div className="h-px bg-white/8" />
+            <div className="space-y-3">
+              <div className="flex items-center justify-between rounded-2xl bg-white/4 px-4 py-3 text-sm">
+                <span className="text-[#D9F99D]">Preparing rows</span>
+                <Shimmer className="h-4 w-12" />
+              </div>
+              <div className="flex items-center justify-between rounded-2xl bg-white/4 px-4 py-3 text-sm">
+                <span className="text-[#D9F99D]">Verifying sync</span>
+                <span className="text-slate-400">Pending</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
 export default function DashboardInteractive({
   rateCards,
 }: {
   rateCards: RateCard[];
 }) {
+  const mounted = useMounted();
   const [cardsReady, setCardsReady] = useState(false);
 
   useEffect(() => {
+    if (!mounted) return;
     const id = requestAnimationFrame(() => setCardsReady(true));
     return () => cancelAnimationFrame(id);
-  }, []);
+  }, [mounted]);
+
+  if (!mounted) {
+    return <DashboardSkeleton />;
+  }
 
   return (
     <>

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, memo } from "react";
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  memo,
+  useSyncExternalStore,
+} from "react";
 import { useRAFInterval } from "@/app/hooks/useRAFInterval";
 import { useInactivityDelay } from "@/app/hooks/useInactivityDelay";
 import { Icon, ICON_IDS } from "@/components/icons";
@@ -8,7 +14,8 @@ import { useProgressBar } from "./TopLoadingBar";
 import { useDebounce } from "../hooks/useDebounce";
 import { useErrorTimeout } from "../hooks/useErrorTimeout";
 import { useSocketConnection, useSocketData } from "./providers/SocketProvider";
-import { Shimmer } from "@/components/skeletons/Shimmer";
+import { PriceFeedCardSkeleton, Shimmer } from "@/components/skeletons";
+import { useMounted } from "@/app/hooks/useMounted";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,6 +38,31 @@ interface PriceFeedCardProps {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function usePageVisibility(): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof document === "undefined") return () => {};
+
+      const handleVisibilityChange = () => {
+        onStoreChange();
+      };
+
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+      return () => {
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange,
+        );
+      };
+    },
+    () =>
+      typeof document === "undefined"
+        ? false
+        : document.visibilityState === "visible",
+    () => false,
+  );
+}
 
 /**
  * Fetches the NGN/XLM price feed from the StellarFlow oracle API.
@@ -100,6 +132,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   refreshInterval = 30_000,
   enableWebSocket = true,
 }) => {
+  const mounted = useMounted();
   const [data, setData] = useState<PriceFeedData | null>(null);
   const [loading, setLoading] = useState(true);
   const { error, setError } = useErrorTimeout({ timeoutMs: 5000 });
@@ -113,6 +146,8 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   // when its specific slice changes, not on every unrelated socket event.
   const { isConnected, error: wsError } = useSocketConnection();
   const { lastUpdate: wsUpdate } = useSocketData();
+
+  const isPageVisible = usePageVisibility();
 
   // Adaptive poll delay — extends the polling interval when the user has been
   // inactive for more than 3 minutes, reducing unnecessary network RPC load.
@@ -143,7 +178,7 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
         if (manual) done();
       }
     },
-    [start, done],
+    [start, done, setError],
   );
 
   // Merge WebSocket delta updates into local state.
@@ -151,42 +186,55 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   // instead of closing over `data` — so `data` is NOT a dependency and the
   // effect does not re-run after every state write, breaking the render cycle.
   useEffect(() => {
+    if (!mounted) return;
+
     if (!wsUpdate || !enableWebSocket || !isPageVisible) return;
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setData((prev: PriceFeedData | null) => ({
-      price: wsUpdate.price || prev?.price || 0,
-      // Reset 24 h change indicator when a fresh price arrives.
-      change_24h: wsUpdate.price ? 0 : prev?.change_24h || 0,
-      high_24h: wsUpdate.price
-        ? Math.max(wsUpdate.price, prev?.high_24h || 0)
-        : prev?.high_24h || 0,
-      low_24h: wsUpdate.price
-        ? Math.min(wsUpdate.price, prev?.low_24h || Infinity)
-        : prev?.low_24h || 0,
-      volume_24h: prev?.volume_24h || 0, // volume comes from REST, not WS
-      last_updated: wsUpdate.timestamp
-        ? new Date(wsUpdate.timestamp).toISOString()
-        : prev?.last_updated || new Date().toISOString(),
-    }));
-    setLastRefresh(new Date());
-    setLoading(false);
-    setError(null);
-  }, [wsUpdate, enableWebSocket]); // `data` intentionally omitted — accessed via functional updater
+    const frameId = window.requestAnimationFrame(() => {
+      setData((prev: PriceFeedData | null) => ({
+        price: wsUpdate.price || prev?.price || 0,
+        // Reset 24 h change indicator when a fresh price arrives.
+        change_24h: wsUpdate.price ? 0 : prev?.change_24h || 0,
+        high_24h: wsUpdate.price
+          ? Math.max(wsUpdate.price, prev?.high_24h || 0)
+          : prev?.high_24h || 0,
+        low_24h: wsUpdate.price
+          ? Math.min(wsUpdate.price, prev?.low_24h || Infinity)
+          : prev?.low_24h || 0,
+        volume_24h: prev?.volume_24h || 0, // volume comes from REST, not WS
+        last_updated: wsUpdate.timestamp
+          ? new Date(wsUpdate.timestamp).toISOString()
+          : prev?.last_updated || new Date().toISOString(),
+      }));
+      setLastRefresh(new Date());
+      setLoading(false);
+      setError(null);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [wsUpdate, enableWebSocket, isPageVisible, mounted, setError]); // `data` intentionally omitted — accessed via functional updater
 
   // Handle WebSocket errors
   useEffect(() => {
+    if (!mounted) return;
+
     if (wsError && enableWebSocket) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(`WebSocket error: ${wsError}`);
     }
-  }, [wsError, enableWebSocket]);
+  }, [wsError, enableWebSocket, mounted, setError]);
 
   // Initial fetch + fallback polling (only when WebSocket is disabled or disconnected)
-  const pollingActive = isPageVisible && (!enableWebSocket || !isConnected);
+  const pollingActive = mounted && isPageVisible && (!enableWebSocket || !isConnected);
   useEffect(() => {
-    if (pollingActive) load();
-  }, [pollingActive, load]);
+    if (!mounted) return;
+    if (!pollingActive) return;
+
+    const id = window.setTimeout(() => {
+      void load();
+    }, 0);
+
+    return () => window.clearTimeout(id);
+  }, [pollingActive, load, mounted]);
 
   // Scale the polling interval by the inactivity multiplier so that background
   // tabs AND idle sessions both reduce network RPC pressure.
@@ -207,22 +255,11 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
     : "shadow-[0_0_18px_rgba(244,63,94,0.18)]";
 
   const priceColor = isUp ? "text-emerald-400" : "text-rose-400";
-  const [isPageVisible, setIsPageVisible] = useState(() => {
-    if (typeof document === "undefined") return true;
-    return document.visibilityState === "visible";
-  });
 
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      setIsPageVisible(document.visibilityState === "visible");
-    };
+  if (!mounted) {
+    return <PriceFeedCardSkeleton />;
+  }
 
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
   return (
     <div
       style={{ contain: "paint layout" }}

--- a/src/app/components/test/WebSocketTest.tsx
+++ b/src/app/components/test/WebSocketTest.tsx
@@ -1,9 +1,33 @@
-'use client'
+"use client";
 
-import React from 'react'
-import { useSocket } from '../../hooks/useSocket'
+import React from "react";
+import { useSocket } from "../../hooks/useSocket";
+import { useMounted } from "@/app/hooks/useMounted";
+import { Shimmer } from "@/components/skeletons/Shimmer";
+
+function WebSocketTestSkeleton() {
+  return (
+    <div className="mx-auto mt-8 max-w-md rounded-lg border border-white/10 bg-gray-900 p-4 text-white" aria-busy="true">
+      <div className="space-y-4">
+        <Shimmer className="h-6 w-48 rounded-md" />
+
+        <div className="space-y-2 text-sm">
+          <Shimmer className="h-8 w-full rounded-md" />
+          <Shimmer className="h-8 w-full rounded-md" />
+          <Shimmer className="h-8 w-full rounded-md" />
+          <Shimmer className="h-24 w-full rounded-md" />
+          <div className="flex gap-2 pt-2">
+            <Shimmer className="h-8 flex-1 rounded-md" />
+            <Shimmer className="h-8 flex-1 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function WebSocketTest() {
+  const mounted = useMounted();
   const {
     isConnected,
     lastUpdate,
@@ -12,57 +36,65 @@ export default function WebSocketTest() {
     subscribeToAsset,
     unsubscribeFromAsset,
   } = useSocket({
-    assetIds: ['NGN-XLM'],
+    assetIds: ["NGN-XLM"],
     enableDeltaUpdates: true,
-  })
+  });
+
+  if (!mounted) {
+    return <WebSocketTestSkeleton />;
+  }
 
   return (
-    <div className="p-4 bg-gray-900 text-white rounded-lg max-w-md mx-auto mt-8">
-      <h2 className="text-xl font-bold mb-4">WebSocket Delta Test</h2>
-      
+    <div className="mx-auto mt-8 max-w-md rounded-lg bg-gray-900 p-4 text-white">
+      <h2 className="mb-4 text-xl font-bold">WebSocket Delta Test</h2>
+
       <div className="space-y-2 text-sm">
-        <div className={`px-3 py-1 rounded ${
-          isConnected ? 'bg-green-600' : 'bg-red-600'
-        }`}>
-          Status: {isConnected ? 'Connected' : 'Disconnected'}
+        <div
+          className={`rounded px-3 py-1 ${
+            isConnected ? "bg-green-600" : "bg-red-600"
+          }`}
+        >
+          Status: {isConnected ? "Connected" : "Disconnected"}
         </div>
-        
-        <div className="px-3 py-1 bg-gray-800 rounded">
+
+        <div className="rounded bg-gray-800 px-3 py-1">
           Reconnect Attempts: {reconnectAttempts}
         </div>
-        
+
         {error && (
-          <div className="px-3 py-1 bg-red-900 rounded text-red-200">
+          <div className="rounded bg-red-900 px-3 py-1 text-red-200">
             Error: {error}
           </div>
         )}
-        
+
         {lastUpdate && (
-          <div className="px-3 py-1 bg-blue-900 rounded">
+          <div className="rounded bg-blue-900 px-3 py-1">
             <div className="font-semibold">Last Update:</div>
             <div className="text-xs">
-              Asset: {lastUpdate.assetPair}<br />
-              Price: {lastUpdate.price.toFixed(6)}<br />
+              Asset: {lastUpdate.assetPair}
+              <br />
+              Price: {lastUpdate.price.toFixed(6)}
+              <br />
               Timestamp: {new Date(lastUpdate.timestamp).toLocaleTimeString()}
             </div>
           </div>
         )}
-        
+
         <div className="flex gap-2 mt-4">
           <button
-            onClick={() => subscribeToAsset('USD-XLM')}
-            className="px-3 py-1 bg-blue-600 rounded text-xs hover:bg-blue-700"
+            onClick={() => subscribeToAsset("USD-XLM")}
+            className="rounded bg-blue-600 px-3 py-1 text-xs hover:bg-blue-700"
           >
             Subscribe USD-XLM
           </button>
           <button
-            onClick={() => unsubscribeFromAsset('USD-XLM')}
-            className="px-3 py-1 bg-orange-600 rounded text-xs hover:bg-orange-700"
+            onClick={() => unsubscribeFromAsset("USD-XLM")}
+            className="rounded bg-orange-600 px-3 py-1 text-xs hover:bg-orange-700"
           >
             Unsubscribe USD-XLM
           </button>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/hooks/useMounted.ts
+++ b/src/app/hooks/useMounted.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export function useMounted(): boolean {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+}

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -322,29 +322,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     };
   }, [connect]);
 
-  // Periodic flush of buffered WebSocket messages every 300ms
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (bufferRef.current.length > 0) {
-        bufferRef.current.forEach((message) => {
-          if (message.type === "price_update" || message.type === "delta_update") {
-            if (message.type === "delta_update" && message.assetId) {
-              setLastUpdate((prev: PriceData | null) =>
-                prev
-                  ? { ...prev, ...(message.data as PriceData) }
-                  : (message.data as PriceData),
-              );
-            } else {
-              setLastUpdate(message.data as PriceData);
-            }
-          }
-        });
-        // Clear buffer after processing
-        bufferRef.current = [];
-      }
-    }, 300);
-    return () => clearInterval(interval);
-  }, []);
   return {
     isConnected,
     lastUpdate,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { ProgressBarProvider } from "./components/TopLoadingBar";
 import { UserProvider } from "./components/providers/UserProvider";
 import { QueryProvider } from "./components/providers/QueryProvider";
 import Script from "next/script";
-import {SocketProvider} from "./components/providers/SocketProvider";
+import { SocketProvider } from "./components/providers/SocketProvider";
 import { SvgSprite } from "@/components/icons";
 
 const geistSans = Geist({
@@ -89,11 +89,11 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <UserProvider>
-            <QueryProvider>
-              <ProgressBarProvider>
-                {children}
-              </ProgressBarProvider>
-            </QueryProvider>
+            <SocketProvider>
+              <QueryProvider>
+                <ProgressBarProvider>{children}</ProgressBarProvider>
+              </QueryProvider>
+            </SocketProvider>
           </UserProvider>
         </ThemeProvider>
       </body>

--- a/src/app/logs/page.tsx
+++ b/src/app/logs/page.tsx
@@ -1,190 +1,381 @@
 "use client";
 
-import React, { useState } from 'react';
-import { Icon, ICON_IDS } from '@/components/icons';
-import { useXdrWorker } from './useXdrWorker';
-import { buildHighlightedParts } from '@/utils/textUtils';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { motion, AnimatePresence } from 'framer-motion';
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { AnimatePresence, motion } from "framer-motion";
+import { buildHighlightedParts, type HighlightPart } from "@/utils/textUtils";
+import { Icon, ICON_IDS } from "@/components/icons";
+import { useMounted } from "@/app/hooks/useMounted";
+import { useXdrWorker } from "./useXdrWorker";
+import { readIndexedLogs, writeIndexedLogs } from "./indexedLogStorage";
+import type { FilteredLogResult, FuseMatch, LogEntry } from "./types";
+import type { XdrFields } from "./worker-types";
 
-import { LogEntry, FilteredLogResult } from './types';
-import { readIndexedLogs, writeIndexedLogs } from './indexedLogStorage';
-import { LogEntry, FilteredLogResult, FuseMatch } from './types';
-
-// --- Mock Data ---
 const MOCK_LOGS: LogEntry[] = [
-  { id: '101', timestamp: '2026-04-28 12:40:01', type: 'transaction', severity: 'info', message: 'XDR: AAAAAEAAAAAEAAAAC...', actor: 'VTPass Lagos', txHash: '0xabc...123' },
-  { id: '102', timestamp: '2026-04-28 12:35:12', type: 'security', severity: 'critical', message: 'Unauthorized API attempt detected from IP 192.168.1.1', actor: 'System Guard' },
-  { id: '103', timestamp: '2026-04-28 12:30:45', type: 'system', severity: 'warning', message: 'Regional Failover: Switching to Frankfurt Secondary', actor: 'Network Orchestrator' },
-  { id: '104', timestamp: '2026-04-28 12:20:10', type: 'transaction', severity: 'info', message: 'XDR: BBBBBEEEEEEFFFFF...', actor: 'Binance Pan-Africa', txHash: '0xdef...456' },
+  {
+    id: "101",
+    timestamp: "2026-04-28 12:40:01",
+    type: "transaction",
+    severity: "info",
+    message: "XDR: AAAAAEAAAAAEAAAAC...",
+    actor: "VTPass Lagos",
+    txHash: "0xabc...123",
+  },
+  {
+    id: "102",
+    timestamp: "2026-04-28 12:35:12",
+    type: "security",
+    severity: "critical",
+    message: "Unauthorized API attempt detected from IP 192.168.1.1",
+    actor: "System Guard",
+  },
+  {
+    id: "103",
+    timestamp: "2026-04-28 12:30:45",
+    type: "system",
+    severity: "warning",
+    message: "Regional Failover: Switching to Frankfurt Secondary",
+    actor: "Network Orchestrator",
+  },
+  {
+    id: "104",
+    timestamp: "2026-04-28 12:20:10",
+    type: "transaction",
+    severity: "info",
+    message: "XDR: BBBBBEEEEEEFFFFF...",
+    actor: "Binance Pan-Africa",
+    txHash: "0xdef...456",
+  },
 ];
 
-const getStartupLogs = () => readIndexedLogs() ?? MOCK_LOGS;
+const SEARCH_FIELDS: Array<keyof Pick<LogEntry, "message" | "actor" | "txHash">> = [
+  "message",
+  "actor",
+  "txHash",
+];
+
+function matchesSeverity(log: LogEntry, severity: "all" | LogEntry["severity"]) {
+  return severity === "all" || log.severity === severity;
+}
+
+function includesQuery(log: LogEntry, query: string) {
+  if (!query) return true;
+
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return SEARCH_FIELDS.some((field) => {
+    const value = log[field];
+    return typeof value === "string" && value.toLowerCase().includes(normalizedQuery);
+  });
+}
+
+function buildMatches(log: LogEntry, query: string): FuseMatch[] | undefined {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return undefined;
+
+  const matches: FuseMatch[] = [];
+  for (const key of SEARCH_FIELDS) {
+    const value = log[key];
+    if (typeof value !== "string") continue;
+
+    const lowerValue = value.toLowerCase();
+    const index = lowerValue.indexOf(normalizedQuery);
+    if (index === -1) continue;
+
+    matches.push({
+      key,
+      indices: [[index, index + normalizedQuery.length - 1]],
+    });
+  }
+
+  return matches.length > 0 ? matches : undefined;
+}
+
+function mergeDecodedLogs(logs: LogEntry[], decodedMap: Map<string, XdrFields>): LogEntry[] {
+  return logs.map((log) => {
+    const decodedData = decodedMap.get(log.id);
+    if (!decodedData) return log;
+    return { ...log, decodedData: decodedData };
+  });
+}
+
+function LogsSkeleton() {
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-8 text-gray-100" aria-busy="true">
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <div className="h-4 w-28 rounded-md bg-white/8" />
+          <div className="h-10 w-56 rounded-md bg-white/10" />
+        </div>
+        <div className="flex gap-3">
+          <div className="h-10 w-32 rounded-lg bg-white/8" />
+          <div className="h-10 w-28 rounded-lg bg-white/8" />
+        </div>
+      </div>
+
+      <div className="mb-6 flex flex-col gap-4 rounded-xl border border-gray-800 bg-[#161b22] p-4 md:flex-row">
+        <div className="h-10 flex-1 rounded-md bg-white/8" />
+        <div className="h-10 w-full rounded-md bg-white/8 md:w-56" />
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-gray-800 bg-[#161b22]">
+        <div className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] border-b border-gray-800 bg-[#0d1117]/80 text-[10px] uppercase tracking-wider text-gray-500">
+          <div className="px-6 py-4">Timestamp</div>
+          <div className="px-6 py-4">Type</div>
+          <div className="px-6 py-4">Severity</div>
+          <div className="px-6 py-4">Event Message</div>
+          <div className="px-6 py-4">Actor</div>
+          <div className="px-6 py-4 text-right">Reference</div>
+        </div>
+
+        <div className="space-y-0">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] border-b border-gray-800/50 items-center"
+            >
+              <div className="px-6 py-4">
+                <div className="h-4 w-28 rounded bg-white/8" />
+              </div>
+              <div className="px-6 py-4">
+                <div className="h-4 w-24 rounded bg-white/8" />
+              </div>
+              <div className="px-6 py-4">
+                <div className="h-6 w-20 rounded-full bg-white/8" />
+              </div>
+              <div className="px-6 py-4">
+                <div className="h-4 w-full rounded bg-white/8" />
+              </div>
+              <div className="px-6 py-4">
+                <div className="h-4 w-24 rounded bg-white/8" />
+              </div>
+              <div className="px-6 py-4 text-right">
+                <div className="ml-auto h-4 w-16 rounded bg-white/8" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function LogsPage() {
-  const [logs] = useState<LogEntry[]>(getStartupLogs);
-  const [filter, setFilter] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [filteredResults, setFilteredResults] = useState<FilteredLogResult[]>(() => logs.map(l => ({ item: l })));
-  const [isSearching, setIsSearching] = React.useState(false);
-  const workerRef = React.useRef<Worker | null>(null);
-
-  // ── XDR Worker (off-thread base64 → binary decoding) ──────────────────
+  const mounted = useMounted();
+  const [logs, setLogs] = useState<LogEntry[]>(MOCK_LOGS);
+  const [filter, setFilter] = useState<"all" | LogEntry["severity"]>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [isOnline, setIsOnline] = useState(true);
+  const [storageReady, setStorageReady] = useState(false);
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const workerRef = useRef<Worker | null>(null);
   const { batchDecode, decoding: xdrDecoding } = useXdrWorker();
 
-  React.useEffect(() => {
-    // Initialise Fuse.js search worker
-    workerRef.current = new Worker(new URL('./search-worker.ts', import.meta.url));
+  useEffect(() => {
+    if (!mounted) return;
 
-    workerRef.current.onmessage = (e) => {
-      if (e.data.type === 'RESULTS') {
-        setFilteredResults(e.data.payload.results);
+    const cachedLogs = readIndexedLogs();
+    if (cachedLogs) {
+      setLogs(cachedLogs);
+    }
+
+    setStorageReady(true);
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!storageReady) return;
+    writeIndexedLogs(logs);
+  }, [logs, storageReady]);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    setIsOnline(navigator.onLine);
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!storageReady) return;
+
+    workerRef.current = new Worker(new URL("./search-worker.ts", import.meta.url));
+
+    workerRef.current.onmessage = (event: MessageEvent<{ type: string; payload?: { results?: FilteredLogResult[] } }>) => {
+      if (event.data.type === "RESULTS" && event.data.payload?.results) {
         setIsSearching(false);
       }
     };
 
-    workerRef.current.postMessage({ type: 'INIT', payload: { logs } });
+    workerRef.current.postMessage({ type: "INIT", payload: { logs } });
 
-    return () => { workerRef.current?.terminate(); };
-  }, [logs]);
+    return () => {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, [logs, storageReady]);
 
-  React.useEffect(() => {
-    writeIndexedLogs(logs);
-  }, [logs]);
+  useEffect(() => {
+    if (!storageReady) return;
 
-  // ── Batch-decode all XDR log lines off the main thread ─────────────────
-  React.useEffect(() => {
     const xdrItems = logs
-      .filter(log => log.message.startsWith('XDR: '))
-      .map(log => ({ id: log.id, xdr: log.message.replace('XDR: ', '') }));
+      .filter((log) => log.message.startsWith("XDR: ") && !log.decodedData)
+      .map((log) => ({ id: log.id, xdr: log.message.replace("XDR: ", "") }));
 
     if (xdrItems.length === 0) return;
 
-    batchDecode('initial-batch', xdrItems).then(results => {
-      setFilteredResults(prev =>
-        prev.map(res => {
-          const hit = results.find(r => r.id === res.item.id);
-          if (!hit || hit.status === 'ERROR') return res;
-          return {
-            ...res,
-            item: { ...res.item, decodedData: hit.decoded_payload },
-          };
-        })
-      );
-    });
-  }, [batchDecode, logs]);
+    batchDecode("initial-batch", xdrItems)
+      .then((results) => {
+        const decodedMap = new Map<string, XdrFields>();
+        for (const result of results) {
+          if (result.status === "ERROR" || !result.decoded_payload) continue;
+          decodedMap.set(result.id, result.decoded_payload);
+        }
+        setLogs((currentLogs) => mergeDecodedLogs(currentLogs, decodedMap));
+      })
+      .catch(() => {
+        // XDR decode errors are already surfaced by the hook.
+      });
+  }, [batchDecode, logs, storageReady]);
 
-  // Handle search with debounce logic
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      if (workerRef.current) {
-        setIsSearching(true);
-        workerRef.current.postMessage({ 
-          type: 'SEARCH', 
-          payload: { query: searchQuery, logs } 
-        });
-      }
-    }, 250); // Debounce search to 250ms to reduce per-keystroke processing
+  const activeLogs = storageReady ? logs : MOCK_LOGS;
 
-    return () => clearTimeout(timer);
-  }, [logs, searchQuery]);
+  const filteredResults = useMemo<FilteredLogResult[]>(() => {
+    const normalizedQuery = searchQuery.trim();
+    const matchedLogs = activeLogs
+      .filter((log) => matchesSeverity(log, filter))
+      .filter((log) => includesQuery(log, normalizedQuery));
 
-  const displayedResults = filteredResults.filter(res => 
-    filter === 'all' || res.item.severity === filter
-  );
+    return matchedLogs.map((log) => ({
+      item: log,
+      matches: buildMatches(log, normalizedQuery),
+    }));
+  }, [activeLogs, filter, searchQuery]);
 
-  // Virtualization setup
-  const parentRef = React.useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!storageReady) return;
+
+    const timer = window.setTimeout(() => {
+      if (!workerRef.current) return;
+      setIsSearching(Boolean(searchQuery.trim()));
+      workerRef.current.postMessage({
+        type: "SEARCH",
+        payload: { query: searchQuery, logs: activeLogs },
+      });
+    }, 250);
+
+    return () => window.clearTimeout(timer);
+  }, [activeLogs, searchQuery, storageReady]);
+
   const rowVirtualizer = useVirtualizer({
-    count: displayedResults.length,
+    count: filteredResults.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 64, // Estimate based on typical row height
-    overscan: 10,
+    estimateSize: () => 72,
+    overscan: 8,
   });
 
-  const [isOnline, setIsOnline] = useState(true);
-  React.useEffect(() => {
-    setIsOnline(navigator.onLine);
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-    return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
-    };
-  }, []);
+  const exportCsv = () => {
+    const headers = ["Timestamp", "Type", "Severity", "Message", "Actor", "Hash"];
+    const csv = [
+      headers.join(","),
+      ...filteredResults.map(({ item }) =>
+        [
+          item.timestamp,
+          item.type,
+          item.severity,
+          `"${item.message.replace(/"/g, '""')}"`,
+          item.actor,
+          item.txHash ?? "",
+        ].join(","),
+      ),
+    ].join("\n");
+
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+
+    anchor.hidden = true;
+    anchor.href = url;
+    anchor.download = `stellarflow_logs_${new Date().toISOString().split("T")[0]}.csv`;
+
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+
+    window.URL.revokeObjectURL(url);
+  };
+
+  const displayedCount = filteredResults.length;
+
+  if (!mounted || !storageReady) {
+    return <LogsSkeleton />;
+  }
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-gray-100 p-8">
-      {/* --- Header Section --- */}
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
+    <div className="min-h-screen bg-[#0a0a0a] p-8 text-gray-100">
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <p className="text-sm text-gray-500 mb-1">Admin / Audit</p>
+          <p className="mb-1 text-sm text-gray-500">Admin / Audit</p>
           <h1 className="text-3xl font-bold tracking-tight">System Logs</h1>
         </div>
+
         <div className="flex items-center gap-3">
-          {/* XDR Worker activity badge — visible while worker thread is busy */}
           {xdrDecoding && (
-            <div className="flex items-center gap-2 bg-purple-500/10 border border-purple-500/30 px-3 py-1.5 rounded-full animate-pulse">
+            <div className="flex items-center gap-2 rounded-full border border-purple-500/30 bg-purple-500/10 px-3 py-1.5 animate-pulse">
               <Icon id={ICON_IDS.cpu} size={13} className="text-purple-400" />
-              <span className="text-xs font-mono text-purple-300 uppercase tracking-wider">Decoding XDR&hellip;</span>
+              <span className="text-xs font-mono uppercase tracking-wider text-purple-300">
+                Decoding XDR…
+              </span>
             </div>
           )}
-          <button 
-            onClick={() => {
-              const headers = ['Timestamp', 'Type', 'Severity', 'Message', 'Actor', 'Hash'];
-              const csv = [
-                headers.join(','),
-                ...displayedResults.map(r => [
-                  r.item.timestamp,
-                  r.item.type,
-                  r.item.severity,
-                  `"${r.item.message.replace(/"/g, '""')}"`,
-                  r.item.actor,
-                  r.item.txHash || ''
-                ].join(','))
-              ].join('\n');
-              
-              const blob = new Blob([csv], { type: 'text/csv' });
-              const url = window.URL.createObjectURL(blob);
-              const a = document.createElement('a');
-              a.setAttribute('hidden', '');
-              a.setAttribute('href', url);
-              a.setAttribute('download', `stellarflow_logs_${new Date().toISOString().split('T')[0]}.csv`);
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-            }}
-            className="flex items-center gap-2 bg-[#161b22] border border-gray-700 hover:bg-gray-800 text-gray-300 px-4 py-2 rounded-lg transition-all text-sm group"
+
+          <button
+            onClick={exportCsv}
+            className="flex items-center gap-2 rounded-lg border border-gray-700 bg-[#161b22] px-4 py-2 text-sm text-gray-300 transition-all hover:bg-gray-800"
           >
-            <Icon id={ICON_IDS.download} size={16} className="group-hover:translate-y-0.5 transition-transform" />
+            <Icon id={ICON_IDS.download} size={16} />
             Export CSV
           </button>
-          <button className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-all text-sm font-medium">
+
+          <button className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-blue-700">
             <Icon id={ICON_IDS.terminal} size={16} />
             Live Console
           </button>
         </div>
       </div>
 
-      {/* --- Filter & Search Bar --- */}
-      <div className="bg-[#161b22] border border-gray-800 rounded-xl p-4 mb-6 flex flex-col md:flex-row gap-4 items-center">
-        <div className="relative flex-1 w-full">
-          <Icon id={ICON_IDS.search} size={18} className={`absolute left-3 top-1/2 -translate-y-1/2 transition-colors ${isSearching ? 'text-blue-500 animate-pulse' : 'text-gray-500'}`} />
-          <input 
-            type="text" 
-            placeholder="Filter logs by message, actor, or hash..." 
+      <div className="mb-6 flex flex-col items-center gap-4 rounded-xl border border-gray-800 bg-[#161b22] p-4 md:flex-row">
+        <div className="relative w-full flex-1">
+          <Icon
+            id={ICON_IDS.search}
+            size={18}
+            className={`absolute left-3 top-1/2 -translate-y-1/2 ${isSearching ? "animate-pulse text-blue-500" : "text-gray-500"}`}
+          />
+          <input
+            type="text"
+            placeholder="Filter logs by message, actor, or hash..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full bg-[#0d1117] border border-gray-700 rounded-md py-2 pl-10 pr-4 text-sm focus:outline-none focus:border-blue-500 transition-colors"
+            onChange={(event) => setSearchQuery(event.target.value)}
+            className="w-full rounded-md border border-gray-700 bg-[#0d1117] py-2 pl-10 pr-4 text-sm outline-none transition-colors focus:border-blue-500"
           />
         </div>
-        <div className="flex items-center gap-2 w-full md:w-auto">
+
+        <div className="flex w-full items-center gap-2 md:w-auto">
           <Icon id={ICON_IDS.filter} size={18} className="text-gray-500" />
-          <select 
-            className="bg-[#0d1117] border border-gray-700 rounded-md py-2 px-4 text-sm focus:outline-none"
-            onChange={(e) => setFilter(e.target.value)}
+          <select
+            className="rounded-md border border-gray-700 bg-[#0d1117] px-4 py-2 text-sm outline-none"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value as "all" | LogEntry["severity"])}
           >
             <option value="all">All Severities</option>
             <option value="info">Info Only</option>
@@ -194,103 +385,119 @@ export default function LogsPage() {
         </div>
       </div>
 
-      {/* --- Logs Virtual Table --- */}
-      <div className="bg-[#161b22] border border-gray-800 rounded-xl overflow-hidden mb-6 relative">
+      <div className="relative mb-6 overflow-hidden rounded-xl border border-gray-800 bg-[#161b22]">
         <AnimatePresence>
           {!isOnline && (
-            <motion.div 
+            <motion.div
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
-              className="absolute top-0 inset-x-0 z-20 bg-yellow-500/90 text-black py-1.5 px-4 flex items-center justify-center gap-2 text-xs font-bold"
+              className="absolute inset-x-0 top-0 z-20 flex items-center justify-center gap-2 bg-yellow-500/90 px-4 py-1.5 text-xs font-bold text-black"
             >
               <Icon id={ICON_IDS.wifiOff} size={14} />
-              Operating in Offline Mode — Cached data is being shown
+              Operating in Offline Mode — cached data is being shown
             </motion.div>
           )}
         </AnimatePresence>
 
-        {/* Sticky header sits outside the scroll container so it never scrolls away */}
-        <div className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] text-gray-500 text-[10px] uppercase tracking-wider border-b border-gray-800 bg-[#0d1117]/80 backdrop-blur-md">
+        <div className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] border-b border-gray-800 bg-[#0d1117]/80 text-[10px] uppercase tracking-wider text-gray-500 backdrop-blur-md">
           <div className="px-6 py-4 font-medium">Timestamp</div>
           <div className="px-6 py-4 font-medium">Type</div>
           <div className="px-6 py-4 font-medium">Severity</div>
           <div className="px-6 py-4 font-medium">Event Message</div>
           <div className="px-6 py-4 font-medium">Actor</div>
-          <div className="px-6 py-4 font-medium text-right">Reference</div>
+          <div className="px-6 py-4 text-right font-medium">Reference</div>
         </div>
 
-        {/* Scroll container — useVirtualizer's getScrollElement targets this ref */}
-        {displayedResults.length === 0 ? (
-          <div className="px-6 py-20 text-center text-gray-500 flex flex-col items-center justify-center gap-2">
+        {displayedCount === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-20 text-center text-gray-500">
             <Icon id={ICON_IDS.search} size={32} className="opacity-20" />
-            <p>No logs matching &ldquo;{searchQuery}&rdquo;</p>
+            <p>No logs matching “{searchQuery}”</p>
           </div>
         ) : (
-          <div
-            ref={parentRef}
-            className="overflow-auto max-h-[600px] scrollbar-thin scrollbar-thumb-gray-700"
-          >
-            {/* Total height spacer — keeps the scrollbar proportional to the full dataset */}
+          <div ref={parentRef} className="max-h-[600px] overflow-auto scrollbar-thin scrollbar-thumb-gray-700">
             <div
               style={{
                 height: `${rowVirtualizer.getTotalSize()}px`,
-                width: '100%',
-                position: 'relative',
+                width: "100%",
+                position: "relative",
               }}
             >
-              {/* Only the rows intersecting the viewport are mounted in the DOM */}
               {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                const result = displayedResults[virtualRow.index];
+                const result = filteredResults[virtualRow.index];
                 const log = result.item;
-                const matches = result.matches || [];
+                const matches = result.matches ?? [];
 
                 return (
                   <div
                     key={virtualRow.key}
-                    data-index={virtualRow.index}
                     ref={rowVirtualizer.measureElement}
+                    data-index={virtualRow.index}
                     style={{
-                      position: 'absolute',
+                      position: "absolute",
                       top: 0,
                       left: 0,
-                      width: '100%',
+                      width: "100%",
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
-                    className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] border-b border-gray-800/50 hover:bg-[#1c2128] transition-colors group font-mono text-[13px] items-center"
+                    className="grid grid-cols-[140px_120px_100px_1fr_150px_120px] items-center border-b border-gray-800/50 font-mono text-[13px] transition-colors hover:bg-[#1c2128]"
                   >
-                    <div className="px-6 py-4 text-gray-400 whitespace-nowrap">
+                    <div className="px-6 py-4 whitespace-nowrap text-gray-400">
                       {log.timestamp}
                     </div>
+
                     <div className="px-6 py-4">
                       <span className="flex items-center gap-2 text-gray-200">
-                        {log.type === 'transaction' && <Icon id={ICON_IDS.database} size={14} className="text-blue-400" />}
-                        {log.type === 'security' && <Icon id={ICON_IDS.shieldAlert} size={14} className="text-red-400" />}
-                        {log.type === 'system' && <Icon id={ICON_IDS.fileText} size={14} className="text-gray-400" />}
+                        {log.type === "transaction" && (
+                          <Icon id={ICON_IDS.database} size={14} className="text-blue-400" />
+                        )}
+                        {log.type === "security" && (
+                          <Icon id={ICON_IDS.shieldAlert} size={14} className="text-red-400" />
+                        )}
+                        {log.type === "system" && (
+                          <Icon id={ICON_IDS.fileText} size={14} className="text-gray-400" />
+                        )}
                         <span className="capitalize">{log.type}</span>
                       </span>
                     </div>
+
                     <div className="px-6 py-4">
                       <SeverityIndicator severity={log.severity} />
                     </div>
-                    <div className="px-6 py-4 truncate text-gray-200">
+
+                    <div className="px-6 py-4 text-gray-200">
                       {log.decodedData ? (
                         <div className="flex flex-col gap-1">
-                          <span className="text-[10px] text-purple-400 uppercase font-bold tracking-wider">Decoded XDR</span>
-                          <span className="text-xs text-green-400 font-mono">{JSON.stringify(log.decodedData)}</span>
+                          <span className="text-[10px] font-bold uppercase tracking-wider text-purple-400">
+                            Decoded XDR
+                          </span>
+                          <span className="font-mono text-xs text-green-400">
+                            {JSON.stringify(log.decodedData)}
+                          </span>
                         </div>
                       ) : (
-                        <SearchHighlight text={log.message} matches={matches.find((m: FuseMatch) => m.key === 'message')?.indices} />
+                        <SearchHighlight
+                          text={log.message}
+                          matches={matches.find((match) => match.key === "message")?.indices}
+                        />
                       )}
                     </div>
-                    <div className="px-6 py-4 text-gray-400 truncate">
-                      <SearchHighlight text={log.actor} matches={matches.find((m: FuseMatch) => m.key === 'actor')?.indices} />
+
+                    <div className="px-6 py-4 text-gray-400">
+                      <SearchHighlight
+                        text={log.actor}
+                        matches={matches.find((match) => match.key === "actor")?.indices}
+                      />
                     </div>
+
                     <div className="px-6 py-4 text-right">
                       {log.txHash ? (
-                        <button className="text-blue-500 hover:text-blue-400 flex items-center gap-1 justify-end ml-auto group/hash">
+                        <button className="group/hash ml-auto flex items-center justify-end gap-1 text-blue-500 hover:text-blue-400">
                           <span className="text-xs uppercase group-hover/hash:underline">
-                            <SearchHighlight text={log.txHash} matches={matches.find((m: FuseMatch) => m.key === 'txHash')?.indices} />
+                            <SearchHighlight
+                              text={log.txHash}
+                              matches={matches.find((match) => match.key === "txHash")?.indices}
+                            />
                           </span>
                           <Icon id={ICON_IDS.externalLink} size={12} />
                         </button>
@@ -299,58 +506,22 @@ export default function LogsPage() {
                       )}
                     </div>
                   </div>
-                     <div className="px-6 py-4 truncate text-gray-200">
-                       {log.decodedData ? (
-                         <div className="flex flex-col gap-1">
-                           <span className="text-[10px] text-purple-400 uppercase font-bold tracking-wider">Decoded XDR</span>
-                           <span className="text-xs text-green-400 font-mono">{JSON.stringify(log.decodedData)}</span>
-                         </div>
-                       ) : (
-                         <SearchHighlight text={log.message} matches={matches.find((m) => m.key === 'message')?.indices} />
-                       )}
-                     </div>
-                     <div className="px-6 py-4 text-gray-400 truncate">
-                       <SearchHighlight text={log.actor} matches={matches.find((m) => m.key === 'actor')?.indices} />
-                     </div>
-                     <div className="px-6 py-4 text-right">
-                       {log.txHash ? (
-                         <button className="text-blue-500 hover:text-blue-400 flex items-center gap-1 justify-end ml-auto group/hash">
-                           <span className="text-xs uppercase group-hover/hash:underline">
-                             <SearchHighlight text={log.txHash} matches={matches.find((m) => m.key === 'txHash')?.indices} />
-                           </span>
-                           <ExternalLink size={12} />
-                         </button>
-                       ) : (
-                         <span className="text-gray-600">—</span>
-                       )}
-                     </div>
-                   </div>
-                 </div>
-               );
-             })}
-
-
-            
-            {displayedResults.length === 0 && (
-              <div className="px-6 py-20 text-center text-gray-500 h-full flex flex-col items-center justify-center gap-2">
-                <Search size={32} className="opacity-20" />
-                <p>No logs matching "{searchQuery}"</p>
-              </div>
-            )}
                 );
               })}
             </div>
           </div>
         )}
 
-        {/* --- Pagination Footer --- */}
-        <div className="p-4 border-t border-gray-800 flex justify-between items-center text-sm text-gray-500">
-          <span>Showing {displayedResults.length} of {logs.length} entries</span>
+        <div className="flex items-center justify-between border-t border-gray-800 p-4 text-sm text-gray-500">
+          <span>
+            Showing {displayedCount} of {activeLogs.length} entries
+          </span>
+
           <div className="flex gap-2">
-            <button className="p-2 border border-gray-700 rounded-md hover:bg-gray-800 disabled:opacity-50" disabled>
+            <button className="rounded-md border border-gray-700 p-2 opacity-50" disabled>
               <Icon id={ICON_IDS.chevronLeft} size={16} />
             </button>
-            <button className="p-2 border border-gray-700 rounded-md hover:bg-gray-800">
+            <button className="rounded-md border border-gray-700 p-2 transition-colors hover:bg-gray-800">
               <Icon id={ICON_IDS.chevronRight} size={16} />
             </button>
           </div>
@@ -360,21 +531,30 @@ export default function LogsPage() {
   );
 }
 
-// --- Sub-components ---
+function SearchHighlight({
+  text,
+  matches,
+}: {
+  text: string;
+  matches?: readonly (readonly [number, number])[];
+}) {
+  const parts = useMemo<HighlightPart[]>(() => buildHighlightedParts(text, matches as [number, number][] | undefined), [text, matches]);
 
-function SearchHighlight({ text, matches }: { text: string; matches?: readonly (readonly [number, number])[] }) {
-  if (!matches || matches.length === 0) return <span>{text}</span>;
-
-  const parts = React.useMemo(() => buildHighlightedParts(text, matches), [deps.text, deps.matchesJson]);
+  if (!matches || matches.length === 0) {
+    return <span>{text}</span>;
+  }
 
   return (
     <span>
-      {parts.map((p, i) =>
-        p.type === 'text' ? (
-          p.text
+      {parts.map((part, index) =>
+        part.type === "text" ? (
+          <React.Fragment key={`${index}-text`}>{part.text}</React.Fragment>
         ) : (
-          <mark key={i} className="bg-[#CBF34D]/30 text-[#CBF34D] rounded-sm px-0.5 border-b border-[#CBF34D]/50 no-underline">
-            {p.text}
+          <mark
+            key={`${index}-match`}
+            className="rounded-sm border-b border-[#CBF34D]/50 bg-[#CBF34D]/30 px-0.5 text-[#CBF34D] no-underline"
+          >
+            {part.text}
           </mark>
         ),
       )}
@@ -382,7 +562,7 @@ function SearchHighlight({ text, matches }: { text: string; matches?: readonly (
   );
 }
 
-function SeverityIndicator({ severity }: { severity: 'info' | 'warning' | 'critical' }) {
+function SeverityIndicator({ severity }: { severity: LogEntry["severity"] }) {
   const styles = {
     info: "text-blue-400 bg-blue-400/10",
     warning: "text-yellow-500 bg-yellow-500/10",
@@ -390,8 +570,11 @@ function SeverityIndicator({ severity }: { severity: 'info' | 'warning' | 'criti
   };
 
   return (
-    <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full w-fit border border-transparent ${styles[severity]}`}>
-      <div className={`w-1.5 h-1.5 rounded-full fill-current ${severity === 'critical' ? 'animate-pulse' : ''}`} style={{ backgroundColor: 'currentColor' }} />
+    <div className={`flex w-fit items-center gap-1.5 rounded-full border border-transparent px-2 py-0.5 ${styles[severity]}`}>
+      <div
+        className={`h-1.5 w-1.5 rounded-full fill-current ${severity === "critical" ? "animate-pulse" : ""}`}
+        style={{ backgroundColor: "currentColor" }}
+      />
       <span className="text-[11px] font-bold uppercase">{severity}</span>
     </div>
   );

--- a/src/components/skeletons/DashboardTrafficChartSkeleton.tsx
+++ b/src/components/skeletons/DashboardTrafficChartSkeleton.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Shimmer } from "./Shimmer";
+
+export const DashboardTrafficChartSkeleton = React.memo(
+  function DashboardTrafficChartSkeleton() {
+    return (
+      <div className="rounded-[32px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+        <div className="mb-5 flex items-center justify-between gap-4 border-b border-white/10 pb-4">
+          <div>
+            <Shimmer className="h-3 w-28 rounded-md" />
+            <Shimmer className="mt-2 h-6 w-44 rounded-md" />
+          </div>
+          <Shimmer className="h-7 w-20 rounded-full" />
+        </div>
+
+        <div className="h-[280px] rounded-[24px] border border-white/10 bg-[#0F172A] p-4">
+          <div className="flex h-full flex-col justify-between gap-4">
+            <div className="space-y-2">
+              <Shimmer className="h-3 w-36 rounded-md" />
+              <Shimmer className="h-3 w-24 rounded-md" />
+            </div>
+
+            <div className="grid flex-1 grid-cols-6 items-end gap-3 rounded-[20px] border border-white/8 bg-white/4 p-4">
+              <Shimmer className="h-12 rounded-t-md" />
+              <Shimmer className="h-20 rounded-t-md" />
+              <Shimmer className="h-28 rounded-t-md" />
+              <Shimmer className="h-24 rounded-t-md" />
+              <Shimmer className="h-32 rounded-t-md" />
+              <Shimmer className="h-36 rounded-t-md" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);

--- a/src/components/skeletons/PriceFeedCardSkeleton.tsx
+++ b/src/components/skeletons/PriceFeedCardSkeleton.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Shimmer } from "./Shimmer";
+
+export const PriceFeedCardSkeleton = React.memo(function PriceFeedCardSkeleton() {
+  return (
+    <div
+      style={{ contain: "paint layout" }}
+      className="relative h-full w-full max-w-full overflow-hidden rounded-2xl border border-[#1B2A3B] bg-[#0A121E] p-6 shadow-lg shadow-black/20"
+      aria-busy="true"
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(57,255,20,0.04),transparent_60%)]" />
+
+      <div className="relative mb-5 flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <Shimmer className="h-2.5 w-20 rounded-full" />
+          <Shimmer className="h-5 w-24 rounded-md" />
+        </div>
+        <Shimmer className="h-6 w-20 rounded-full" />
+      </div>
+
+      <div className="relative mb-5 space-y-3">
+        <Shimmer className="h-10 w-3/4" />
+        <Shimmer className="h-5 w-1/3" />
+      </div>
+
+      <div className="relative grid grid-cols-1 gap-3 border-t border-[#1B2A3B] pt-4 sm:grid-cols-3">
+        <Shimmer className="h-10 rounded-xl" />
+        <Shimmer className="h-10 rounded-xl" />
+        <Shimmer className="h-10 rounded-xl" />
+      </div>
+
+      <div className="relative mt-4">
+        <Shimmer className="h-8 w-full rounded-lg" />
+      </div>
+
+      <div className="relative mt-4 flex items-center justify-between">
+        <Shimmer className="h-3 w-24" />
+        <Shimmer className="h-3 w-20" />
+      </div>
+    </div>
+  );
+});

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -2,3 +2,5 @@ export { Shimmer } from './Shimmer';
 export { MetricCardSkeleton } from './MetricCardSkeleton';
 export { MapSkeleton } from './MapSkeleton';
 export { RateSparklineSkeleton } from './RateSparklineSkeleton';
+export { PriceFeedCardSkeleton } from './PriceFeedCardSkeleton';
+export { DashboardTrafficChartSkeleton } from './DashboardTrafficChartSkeleton';


### PR DESCRIPTION
#324 🛡️ Strict-Hydration | Safe Server Skeleton Mappings for Cryptographic Layouts
What changed:
Tightened the mount gate in useMounted.ts (line 5) so server and first-client render stay on the static path.
Wired `SocketProvider` (line 91) into the root layout so the live price feed context is actually available at runtime.
Added reusable, size-matched skeletons for the live price card and traffic chart in PriceFeedCardSkeleton.tsx (line 4) and DashboardTrafficChartSkeleton.tsx (line 4), then exported them from skeletons/index.ts (line 1).
Reworked DashboardInteractive.tsx (line 49) so the initial server fallback uses the exact same structural shells as the hydrated dashboard, instead of generic placeholders.
Hardened PriceFeedCard.tsx (line 259) so it returns the shared skeleton until mount, and only then starts processing browser/sockets-dependent values.
Kept the chart component purely client-side and aligned its loading state in DashboardTrafficChart.tsx (line 33).

closes #324 