### PR TITLE
perf: disable auto-prefetch on sidebar nav links

### DIFF
--- a/src/app/components/server/Sidebar.tsx
+++ b/src/app/components/server/Sidebar.tsx
@@ -6,10 +6,10 @@ export default function Sidebar() {
       <h2 className="text-xl font-bold mb-6">Dashboard</h2>
 
       <nav className="space-y-4">
-        <Link href="/">Home</Link>
-        <Link href="/analytics">Analytics</Link>
-        <Link href="/transactions">Transactions</Link>
-        <Link href="/settings">Settings</Link>
+        <Link href="/" prefetch={false}>Home</Link>
+        <Link href="/analytics" prefetch={false}>Analytics</Link>
+        <Link href="/transactions" prefetch={false}>Transactions</Link>
+        <Link href="/settings" prefetch={false}>Settings</Link>
       </nav>
     </aside>
   )


### PR DESCRIPTION
perf: disable auto-prefetch on sidebar nav links
  
  Adds prefetch={false} to all <Link> elements in server/Sidebar.tsx to prevent
  Next.js from automatically prefetching navigation routes in the background.
  
  Why: Next.js prefetches all in-viewport links by default, which floods the
  network with background script downloads — especially problematic on
  low-bandwidth connections. The FloatingSidebar already handles intent-based
  prefetching via router.prefetch() on hover/focus, making automatic prefetching
  redundant.
  
  Changes:
  
  - src/app/components/server/Sidebar.tsx — added prefetch={false} to all 4 nav
  links
  
  Tested: No functional change to navigation behavior. Prefetch is still
  triggered on user hover intent via FloatingSidebar.
closes #318
