### PR TITLE
Bundle-Size | Isolating Heavy Cryptographic Keypair Utilities

### DIFF
--- a/.kiro/specs/crypto-bundle-isolation/.config.kiro
+++ b/.kiro/specs/crypto-bundle-isolation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "fe8350a4-a831-4d90-a60d-72074a785a01", "workflowType": "fast-task", "specType": "feature"}

--- a/.kiro/specs/crypto-bundle-isolation/design.md
+++ b/.kiro/specs/crypto-bundle-isolation/design.md
@@ -1,0 +1,499 @@
+# Design Document — Crypto Bundle Isolation
+
+## Overview
+
+This document describes the technical design for isolating heavy cryptographic keypair utilities from the main dashboard bundle in `stellarflow-frontend`. The solution introduces three coordinated pieces:
+
+1. **`src/lib/crypto/keypairUtils.ts`** — the single authoritative Crypto_Wrapper that holds all static imports of cryptographic libraries.
+2. **`src/app/crypto-tools/page.tsx`** — the Lazy_Crypto_Page, a standalone Next.js App Router page that loads the wrapper on demand.
+3. **Extensions to `scripts/check-bundle-size.js`** — Exclusion_Assertion logic that scans the built Dashboard_Bundle for forbidden crypto identifiers and reports violations in `.bundle-report.json`.
+
+No changes are made to `src/app/logs/xdr-worker.ts`, `src/app/page.tsx`, or `src/app/layout.tsx`.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Dashboard_Bundle  (page.tsx + layout.tsx + shared chunks)      │
+│                                                                 │
+│  ✅ Nav, FloatingSidebar, SystemStats, ModularStatsCard, …      │
+│  ✅ XDR_Worker  (independent Web Worker thread)                 │
+│  ✗  NO stellar-sdk / tweetnacl / @noble/ed25519                 │
+└─────────────────────────────────────────────────────────────────┘
+          │  Next.js Router navigates to /crypto-tools
+          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Lazy_Crypto_Page chunk  (src/app/crypto-tools/page.tsx)        │
+│                                                                 │
+│  next/dynamic(() => import('../../../lib/crypto/keypairUtils')) │
+│         │                                                       │
+│         ▼                                                       │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  Crypto_Wrapper  (src/lib/crypto/keypairUtils.ts)        │  │
+│  │  — static import stellar-sdk (Keypair)                   │  │
+│  │  — static import tweetnacl (sign / verify)               │  │
+│  │  — exports: generateKeypair, signPayload, verifySignature│  │
+│  └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Bundle_Checker  (scripts/check-bundle-size.js)                 │
+│                                                                 │
+│  Post-build scan of .next/static/chunks/                        │
+│  Exclusion_Assertion: grep main-* chunks for forbidden IDs      │
+│  Reports cryptoExclusionViolations[] in .bundle-report.json     │
+│  --strict: exit 1 on any violation                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Component Design
+
+### 1. Crypto_Wrapper — `src/lib/crypto/keypairUtils.ts`
+
+This is the **only** file in `src/` that may contain a static `import` of a cryptographic keypair library.
+
+```typescript
+// src/lib/crypto/keypairUtils.ts
+
+import { Keypair } from 'stellar-sdk';
+import nacl from 'tweetnacl';
+
+export interface GeneratedKeypair {
+  publicKey: string;
+  secretKey: string;
+}
+
+export interface SignResult {
+  signature: string; // hex-encoded
+  publicKey: string;
+}
+
+export interface VerifyResult {
+  valid: boolean;
+}
+
+/**
+ * Generates a random Stellar keypair.
+ * Returns synchronously — Keypair.random() is CPU-bound, not async.
+ */
+export function generateKeypair(): GeneratedKeypair {
+  const kp = Keypair.random();
+  return {
+    publicKey: kp.publicKey(),
+    secretKey: kp.secret(),
+  };
+}
+
+/**
+ * Derives a keypair from an existing Stellar secret key (S…).
+ * Throws a descriptive error if the secret is malformed.
+ */
+export function keypairFromSecret(secret: string): GeneratedKeypair {
+  try {
+    const kp = Keypair.fromSecret(secret);
+    return { publicKey: kp.publicKey(), secretKey: kp.secret() };
+  } catch (err) {
+    throw new Error(
+      `stellar-sdk: Keypair.fromSecret failed — ${(err as Error).message}`
+    );
+  }
+}
+
+/**
+ * Signs an arbitrary UTF-8 message with a Stellar secret key.
+ * Uses tweetnacl Ed25519 under the hood.
+ */
+export function signPayload(message: string, secret: string): SignResult {
+  const kp = Keypair.fromSecret(secret);
+  const msgBytes = new TextEncoder().encode(message);
+  const sigBytes = nacl.sign.detached(msgBytes, kp.rawSecretKey());
+  return {
+    signature: Buffer.from(sigBytes).toString('hex'),
+    publicKey: kp.publicKey(),
+  };
+}
+
+/**
+ * Verifies an Ed25519 signature produced by signPayload.
+ * publicKey must be a Stellar G… address.
+ */
+export function verifySignature(
+  message: string,
+  signatureHex: string,
+  publicKey: string
+): VerifyResult {
+  try {
+    const kp = Keypair.fromPublicKey(publicKey);
+    const msgBytes = new TextEncoder().encode(message);
+    const sigBytes = Buffer.from(signatureHex, 'hex');
+    const valid = nacl.sign.detached.verify(
+      msgBytes,
+      sigBytes,
+      kp.rawPublicKey()
+    );
+    return { valid };
+  } catch {
+    return { valid: false };
+  }
+}
+```
+
+**Key constraints:**
+- No top-level side effects (no key generation at module evaluation time).
+- All exports are pure functions.
+- Error messages always name the failing library (`stellar-sdk`, `tweetnacl`).
+
+---
+
+### 2. Lazy_Crypto_Page — `src/app/crypto-tools/page.tsx`
+
+A Next.js App Router page at `/crypto-tools`. It uses `next/dynamic` with `ssr: false` to defer the Crypto_Wrapper chunk until the page is rendered in the browser.
+
+```typescript
+// src/app/crypto-tools/page.tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// Dynamically import the heavy crypto UI component.
+// ssr: false ensures the Crypto_Wrapper chunk is never included in SSR output
+// or the Dashboard_Bundle's server-side dependency graph.
+const CryptoToolsPanel = dynamic(
+  () => import('../../components/crypto/CryptoToolsPanel'),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        role="status"
+        aria-label="Loading cryptographic tools"
+        className="flex items-center justify-center min-h-[200px] text-gray-400"
+      >
+        <span className="animate-pulse">Loading crypto tools…</span>
+      </div>
+    ),
+  }
+);
+
+export default function CryptoToolsPage() {
+  return (
+    <main className="min-h-screen bg-[#020817] text-white px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-6">Cryptographic Utilities</h1>
+      <CryptoToolsPanel />
+    </main>
+  );
+}
+```
+
+---
+
+### 3. CryptoToolsPanel — `src/app/components/crypto/CryptoToolsPanel.tsx`
+
+This client component is the actual consumer of the Crypto_Wrapper. It is only ever loaded via the `dynamic()` call above.
+
+```typescript
+// src/app/components/crypto/CryptoToolsPanel.tsx
+'use client';
+
+import { useState } from 'react';
+import type { GeneratedKeypair, SignResult, VerifyResult } from '../../../lib/crypto/keypairUtils';
+
+// Runtime dynamic import — NOT a static top-level import.
+// This is the correct pattern for consuming the Crypto_Wrapper.
+async function loadCrypto() {
+  const mod = await import('../../../lib/crypto/keypairUtils');
+  return mod;
+}
+
+export default function CryptoToolsPanel() {
+  const [keypair, setKeypair] = useState<GeneratedKeypair | null>(null);
+  const [signResult, setSignResult] = useState<SignResult | null>(null);
+  const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+  const [secret, setSecret] = useState('');
+  const [sigHex, setSigHex] = useState('');
+  const [pubKey, setPubKey] = useState('');
+
+  async function handleGenerate() {
+    setError(null);
+    try {
+      const { generateKeypair } = await loadCrypto();
+      setKeypair(generateKeypair());
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  async function handleSign() {
+    setError(null);
+    try {
+      const { signPayload } = await loadCrypto();
+      setSignResult(signPayload(message, secret));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  async function handleVerify() {
+    setError(null);
+    try {
+      const { verifySignature } = await loadCrypto();
+      setVerifyResult(verifySignature(message, sigHex, pubKey));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {error && (
+        <div role="alert" className="text-red-400 border border-red-700 rounded p-3">
+          {error}
+        </div>
+      )}
+
+      {/* Keypair Generation UI */}
+      <section aria-labelledby="keygen-heading">
+        <h2 id="keygen-heading" className="text-lg font-medium mb-3">Keypair Generation</h2>
+        <button onClick={handleGenerate} className="btn-primary">Generate Keypair</button>
+        {keypair && (
+          <dl className="mt-3 space-y-1 text-sm font-mono break-all">
+            <dt className="text-gray-400">Public Key</dt>
+            <dd>{keypair.publicKey}</dd>
+            <dt className="text-gray-400 mt-2">Secret Key</dt>
+            <dd>{keypair.secretKey}</dd>
+          </dl>
+        )}
+      </section>
+
+      {/* Signature Validation UI */}
+      <section aria-labelledby="sign-heading">
+        <h2 id="sign-heading" className="text-lg font-medium mb-3">Sign &amp; Verify</h2>
+        <div className="space-y-2">
+          <input value={message} onChange={e => setMessage(e.target.value)}
+            placeholder="Message to sign" className="input-field w-full" />
+          <input value={secret} onChange={e => setSecret(e.target.value)}
+            placeholder="Secret key (S…)" className="input-field w-full" type="password" />
+          <button onClick={handleSign} className="btn-primary">Sign</button>
+        </div>
+        {signResult && (
+          <p className="mt-2 text-sm font-mono break-all">Signature: {signResult.signature}</p>
+        )}
+        <div className="space-y-2 mt-4">
+          <input value={sigHex} onChange={e => setSigHex(e.target.value)}
+            placeholder="Signature (hex)" className="input-field w-full" />
+          <input value={pubKey} onChange={e => setPubKey(e.target.value)}
+            placeholder="Public key (G…)" className="input-field w-full" />
+          <button onClick={handleVerify} className="btn-primary">Verify</button>
+        </div>
+        {verifyResult && (
+          <p className={`mt-2 font-semibold ${verifyResult.valid ? 'text-green-400' : 'text-red-400'}`}>
+            {verifyResult.valid ? '✓ Valid signature' : '✗ Invalid signature'}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+```
+
+---
+
+## Bundle_Checker Extensions
+
+### New fields in `.bundle-limits.json`
+
+```json
+{
+  "maxMainBundle": 250,
+  "maxPageBundle": 100,
+  "maxTotalGzipped": 500,
+  "maxIndividualGzipped": 150,
+  "cryptoIsolation": true,
+  "cryptoWrapperChunkWarningKb": 150,
+  "forbiddenInMainBundle": [
+    "stellar-sdk",
+    "stellar_sdk",
+    "tweetnacl",
+    "@noble/ed25519",
+    "noble/ed25519",
+    "keypairUtils"
+  ]
+}
+```
+
+- `cryptoIsolation: true` — activates Exclusion_Assertion scanning.
+- `forbiddenInMainBundle` — exhaustive list of identifiers that must not appear in main-* chunks.
+- `cryptoWrapperChunkWarningKb` — threshold for the non-blocking warning on the lazy crypto chunk.
+
+### Extended report schema (`.bundle-report.json`)
+
+```jsonc
+{
+  "timestamp": "…",
+  "limits": { /* .bundle-limits.json contents */ },
+  "bundles": [ /* existing per-chunk entries */ ],
+  "totalGzipped": 0,
+  "violations": [ /* existing size violations */ ],
+  "passed": true,
+
+  // NEW fields
+  "cryptoIsolation": {
+    "enabled": true,
+    "cryptoExclusionViolations": [
+      // populated when a forbidden identifier is found in a main-* chunk
+      {
+        "chunk": "main-abc123.js",
+        "identifier": "stellar-sdk",
+        "message": "Forbidden identifier 'stellar-sdk' found in main chunk 'main-abc123.js'"
+      }
+    ],
+    "cryptoWrapperChunk": {
+      "name": "crypto-keypairUtils-xyz.js",  // null if not found
+      "gzipped": 0                            // KB
+    },
+    "verified": true   // true when cryptoExclusionViolations is empty
+  }
+}
+```
+
+### Logic additions to `scripts/check-bundle-size.js`
+
+The following logic is added after the existing bundle scan loop:
+
+```javascript
+// ── Crypto Exclusion Assertion ────────────────────────────────────────────────
+function runCryptoExclusionAssertion(report, limits, jsDir, files) {
+  if (!limits.cryptoIsolation) return;
+
+  const forbidden = limits.forbiddenInMainBundle || [];
+  const cryptoExclusionViolations = [];
+  let cryptoWrapperChunk = { name: null, gzipped: 0 };
+
+  files.forEach(file => {
+    const filePath = path.join(jsDir, file);
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    // Identify the crypto wrapper lazy chunk by filename pattern
+    if (file.includes('crypto') || file.includes('keypairUtils')) {
+      const gzipped = parseFloat(getGzippedSizeKb(filePath));
+      cryptoWrapperChunk = { name: file, gzipped };
+
+      // Warn (non-blocking) if the lazy chunk is too large
+      if (gzipped > (limits.cryptoWrapperChunkWarningKb || 150)) {
+        console.warn(
+          `⚠️  Crypto wrapper chunk '${file}' is ${gzipped}KB gzipped ` +
+          `(>${limits.cryptoWrapperChunkWarningKb}KB). Consider further code splitting.`
+        );
+      }
+    }
+
+    // Only scan main-* chunks for forbidden identifiers
+    if (!file.startsWith('main')) return;
+
+    forbidden.forEach(id => {
+      if (content.includes(id)) {
+        const msg = `Forbidden identifier '${id}' found in main chunk '${file}'`;
+        cryptoExclusionViolations.push({ chunk: file, identifier: id, message: msg });
+        report.violations.push(msg);
+        report.passed = false;
+      }
+    });
+  });
+
+  const verified = cryptoExclusionViolations.length === 0;
+
+  report.cryptoIsolation = {
+    enabled: true,
+    cryptoExclusionViolations,
+    cryptoWrapperChunk,
+    verified,
+  };
+
+  if (verified) {
+    console.log('🔐 Crypto isolation verified — no forbidden identifiers in main bundle.');
+  } else {
+    console.error(`❌ Crypto isolation FAILED — ${cryptoExclusionViolations.length} violation(s) found.`);
+    cryptoExclusionViolations.forEach(v => console.error(`   • ${v.message}`));
+  }
+}
+```
+
+This function is called inside `analyzeBundles()` after the existing per-file loop, passing the same `files` array and `jsDir`.
+
+---
+
+## GitHub Actions Workflow Changes
+
+The existing workflow already runs `npm run build:strict` which invokes `node scripts/check-bundle-size.js --strict`. No structural changes are needed. The Exclusion_Assertion violations are added to `report.violations[]`, so the existing `--strict` exit-1 path already covers them.
+
+The PR comment step is extended to surface crypto isolation status:
+
+```yaml
+# In the "Comment PR with bundle report" step, add after the violations block:
+if (report.cryptoIsolation) {
+  const ci = report.cryptoIsolation;
+  comment += ci.verified
+    ? '\n🔐 **Crypto isolation: ✅ verified**\n'
+    : '\n🔐 **Crypto isolation: ❌ FAILED**\n';
+  if (ci.cryptoWrapperChunk.name) {
+    comment += `- Crypto wrapper chunk: \`${ci.cryptoWrapperChunk.name}\` — ${ci.cryptoWrapperChunk.gzipped}KB gzipped\n`;
+  }
+  if (ci.cryptoExclusionViolations.length > 0) {
+    comment += '\n### 🔐 Crypto Isolation Violations:\n';
+    ci.cryptoExclusionViolations.forEach(v => {
+      comment += `- ${v.message}\n`;
+    });
+  }
+}
+```
+
+---
+
+## XDR Worker Non-Interference
+
+`src/app/logs/xdr-worker.ts` is a self-contained Web Worker that performs base64 XDR decoding using only browser-native APIs (`atob`, `Uint8Array`, `TextEncoder`). It has no dependency on `stellar-sdk`, `tweetnacl`, or any cryptographic keypair library.
+
+The Crypto_Wrapper (`src/lib/crypto/keypairUtils.ts`) has no import of or dependency on the XDR worker. The two modules are completely orthogonal:
+
+| Module | Imports crypto libs | Imports XDR worker |
+|---|---|---|
+| `src/lib/crypto/keypairUtils.ts` | ✅ yes (stellar-sdk, tweetnacl) | ✗ no |
+| `src/app/logs/xdr-worker.ts` | ✗ no | — |
+
+No modifications to `xdr-worker.ts` are required or permitted.
+
+---
+
+## File Changeset Summary
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/lib/crypto/keypairUtils.ts` | **Create** | Crypto_Wrapper — sole static importer of crypto libs |
+| `src/app/crypto-tools/page.tsx` | **Create** | Lazy_Crypto_Page at `/crypto-tools` |
+| `src/app/components/crypto/CryptoToolsPanel.tsx` | **Create** | UI panel loaded via `next/dynamic` |
+| `.bundle-limits.json` | **Modify** | Add `cryptoIsolation`, `forbiddenInMainBundle`, `cryptoWrapperChunkWarningKb` |
+| `scripts/check-bundle-size.js` | **Modify** | Add `runCryptoExclusionAssertion()` and crypto chunk reporting |
+| `.github/workflows/bundle-check.yml` | **Modify** | Extend PR comment to surface crypto isolation status |
+| `docs/CRYPTO_BUNDLE_ISOLATION.md` | **Create** | Developer documentation |
+| `src/app/logs/xdr-worker.ts` | **No change** | Must remain unmodified |
+| `src/app/page.tsx` | **No change** | Dashboard_Bundle entry point — no crypto imports |
+| `src/app/layout.tsx` | **No change** | Root layout — no crypto imports |
+
+---
+
+## Dependency Requirements
+
+The Crypto_Wrapper requires `stellar-sdk` and `tweetnacl`. Neither is currently in `package.json`. They must be added as production dependencies with pinned versions:
+
+```json
+"stellar-sdk": "12.3.0",
+"tweetnacl": "1.0.3"
+```
+
+These packages are only reachable via the lazy chunk — they will not appear in the Dashboard_Bundle because no static import path from `page.tsx` or `layout.tsx` reaches `keypairUtils.ts`.

--- a/.kiro/specs/crypto-bundle-isolation/requirements.md
+++ b/.kiro/specs/crypto-bundle-isolation/requirements.md
@@ -1,0 +1,117 @@
+# Requirements Document
+
+## Introduction
+
+The stellarflow-frontend dashboard serves users who primarily read public price feeds, relayer status, and governance data. Currently, the project is structured to add heavy cryptographic keypair utilities (e.g., Stellar keypair generation, Ed25519 signature validation) directly into shared module scope. Because these libraries are not tree-shakable in their common distribution forms, any static import causes the entire cryptographic payload to be bundled into the main dashboard chunk — inflating the initial download for every user regardless of whether they ever interact with keypair or signing features.
+
+This feature establishes the architectural rules, dynamic-import wrappers, dedicated utility entry points, and automated compilation checks that ensure cryptographic keypair utilities are permanently excluded from the main dashboard bundle. The existing bundle-size enforcement pipeline (`check-bundle-size.js`, `.bundle-limits.json`, and the GitHub Actions workflow) is extended to include crypto-specific exclusion assertions.
+
+## Glossary
+
+- **Bundle_Checker**: The Node.js script at `scripts/check-bundle-size.js` that analyses `.next/static/chunks/` after a build and reports size violations.
+- **Crypto_Wrapper**: A dedicated TypeScript module (e.g., `src/lib/crypto/keypairUtils.ts`) that re-exports keypair and signature utilities and is only ever imported via `next/dynamic` or `import()`.
+- **Dashboard_Bundle**: The main JavaScript chunk(s) emitted by Next.js for the root layout and the public-facing dashboard page (`src/app/page.tsx` and `src/app/layout.tsx`).
+- **Dynamic_Import**: A JavaScript `import()` expression or Next.js `dynamic()` call that causes the module graph to be split at that boundary, deferring the load of the target module until it is actually needed at runtime.
+- **Exclusion_Assertion**: A compile-time or post-build check that fails the build if a forbidden module identifier is detected inside a specified bundle.
+- **Keypair_Utility**: Any function that creates, derives, or validates a cryptographic keypair or digital signature, including but not limited to Stellar `Keypair.random()`, `Keypair.fromSecret()`, and Ed25519 `sign` / `verify` primitives.
+- **Lazy_Crypto_Page**: A Next.js page route (e.g., `src/app/crypto-tools/page.tsx`) whose sole purpose is to host keypair and signature UI, loaded entirely on demand.
+- **Static_Import**: A top-level `import … from '…'` statement that is resolved at compile time and always included in the bundle that contains the importing module.
+- **XDR_Worker**: The existing Web Worker at `src/app/logs/xdr-worker.ts` that performs base64 XDR decoding off the main thread; it does not use keypair utilities and must remain unaffected.
+
+## Requirements
+
+### Requirement 1: Crypto_Wrapper Module Isolation
+
+**User Story:** As a frontend engineer, I want all keypair and signature utilities to live behind a single dedicated wrapper module, so that there is one authoritative place to add or remove cryptographic dependencies without risking accidental static imports elsewhere.
+
+#### Acceptance Criteria
+
+1. THE Crypto_Wrapper SHALL export all Keypair_Utility functions used by the application.
+2. THE Crypto_Wrapper SHALL NOT contain any top-level side-effectful code that executes on module evaluation (e.g., key generation at import time).
+3. WHEN a Keypair_Utility function is invoked, THE Crypto_Wrapper SHALL return the result synchronously or via a Promise, depending on the underlying library's API contract.
+4. IF the underlying cryptographic library is unavailable at runtime, THEN THE Crypto_Wrapper SHALL throw a descriptive error identifying the missing dependency by name.
+5. THE Crypto_Wrapper SHALL be the only module in the `src/` tree that contains a Static_Import of any cryptographic keypair library.
+
+---
+
+### Requirement 2: Dynamic Import Enforcement for Keypair Features
+
+**User Story:** As a performance-conscious engineer, I want every consumer of keypair utilities to load them through a Dynamic_Import, so that the cryptographic payload is never included in the initial page load for dashboard readers.
+
+#### Acceptance Criteria
+
+1. WHEN a UI component requires a Keypair_Utility, THE component SHALL load the Crypto_Wrapper exclusively via a Dynamic_Import or `next/dynamic` call.
+2. WHEN the Dynamic_Import is in flight, THE component SHALL render a non-blocking loading indicator rather than blocking the render tree.
+3. WHEN the Dynamic_Import resolves, THE component SHALL make the Keypair_Utility available to the user without a full page reload.
+4. IF the Dynamic_Import fails (e.g., network error, module parse error), THEN THE component SHALL display a user-visible error message and SHALL NOT silently swallow the failure.
+5. THE Dashboard_Bundle SHALL NOT contain any module identifier matching the Crypto_Wrapper's file path after a production build.
+
+---
+
+### Requirement 3: Lazy_Crypto_Page Route
+
+**User Story:** As a developer, I want a dedicated standalone page route for keypair and signature tooling, so that users who need those features can navigate to them on demand without affecting the dashboard's initial load performance.
+
+#### Acceptance Criteria
+
+1. THE Lazy_Crypto_Page SHALL be reachable at a distinct URL path (e.g., `/crypto-tools`) that is separate from the main dashboard route.
+2. WHEN a user navigates to the Lazy_Crypto_Page, THE Next.js Router SHALL load the page's JavaScript chunk independently of the Dashboard_Bundle.
+3. THE Lazy_Crypto_Page SHALL import the Crypto_Wrapper using a Dynamic_Import so that the cryptographic library chunk is deferred until the page is rendered.
+4. WHEN the Lazy_Crypto_Page is rendered, THE page SHALL display at minimum a keypair generation UI and a signature validation UI.
+5. THE Lazy_Crypto_Page chunk SHALL NOT be included in the Dashboard_Bundle's dependency graph.
+
+---
+
+### Requirement 4: Static Import Prohibition Lint Rule
+
+**User Story:** As a team lead, I want an automated lint check that prevents engineers from accidentally adding a Static_Import of any cryptographic keypair library outside the Crypto_Wrapper, so that bundle isolation is enforced continuously rather than relying on manual code review.
+
+#### Acceptance Criteria
+
+1. THE Bundle_Checker SHALL include an Exclusion_Assertion that scans the built Dashboard_Bundle for the presence of known cryptographic library identifiers (e.g., `stellar-sdk`, `tweetnacl`, `@noble/ed25519`).
+2. WHEN a forbidden identifier is detected in the Dashboard_Bundle, THE Bundle_Checker SHALL emit a named violation entry in the `.bundle-report.json` output.
+3. WHEN running in strict mode (`--strict` flag), THE Bundle_Checker SHALL exit with a non-zero status code if any Exclusion_Assertion violation is found.
+4. THE GitHub Actions workflow SHALL invoke the Bundle_Checker in strict mode on every pull request targeting `main` or `develop`.
+5. IF no forbidden identifiers are found in the Dashboard_Bundle, THEN THE Bundle_Checker SHALL emit a confirmation message indicating that crypto isolation is verified.
+
+---
+
+### Requirement 5: Bundle Size Regression Guard for Crypto Isolation
+
+**User Story:** As a CI/CD maintainer, I want the bundle size limits to be tightened to reflect the expected savings from crypto isolation, so that any future regression that re-introduces heavy crypto into the main bundle is caught automatically.
+
+#### Acceptance Criteria
+
+1. WHEN crypto isolation is active, THE Bundle_Checker SHALL enforce a `maxMainBundle` limit that is at most 250 KB (gzipped), consistent with the existing `.bundle-limits.json` configuration.
+2. WHEN a new cryptographic dependency is added to the project, THE developer SHALL update the Crypto_Wrapper and SHALL NOT increase the `maxMainBundle` limit in `.bundle-limits.json` without a documented justification comment in the pull request.
+3. THE Bundle_Checker SHALL report the gzipped size of the Crypto_Wrapper's lazy chunk separately from the Dashboard_Bundle in the `.bundle-report.json` output.
+4. WHEN the Crypto_Wrapper's lazy chunk exceeds 150 KB gzipped, THE Bundle_Checker SHALL emit a warning (non-blocking) recommending further code splitting.
+5. THE total gzipped size of all bundles SHALL remain within the `maxTotalGzipped` limit defined in `.bundle-limits.json`.
+
+---
+
+### Requirement 6: XDR Worker Non-Interference
+
+**User Story:** As a developer, I want the crypto isolation changes to leave the existing XDR_Worker and its surrounding infrastructure completely unmodified, so that audit log decoding continues to work without regression.
+
+#### Acceptance Criteria
+
+1. THE XDR_Worker at `src/app/logs/xdr-worker.ts` SHALL NOT be modified as part of the crypto isolation implementation.
+2. WHILE the Lazy_Crypto_Page is loading, THE XDR_Worker SHALL remain operational and SHALL continue to process `DECODE_XDR` and `BATCH_DECODE` messages.
+3. THE Crypto_Wrapper SHALL NOT import from or depend on the XDR_Worker module.
+4. THE XDR_Worker SHALL NOT import from or depend on the Crypto_Wrapper module.
+5. IF the Crypto_Wrapper's Dynamic_Import fails, THEN THE XDR_Worker's message-handling loop SHALL be unaffected.
+
+---
+
+### Requirement 7: Developer Documentation
+
+**User Story:** As a new contributor, I want clear documentation explaining the crypto bundle isolation architecture, so that I understand where to add new cryptographic utilities and how to verify that isolation is maintained.
+
+#### Acceptance Criteria
+
+1. THE project SHALL contain a documentation file (e.g., `docs/CRYPTO_BUNDLE_ISOLATION.md`) that describes the Crypto_Wrapper pattern, the Lazy_Crypto_Page route, and the Exclusion_Assertion checks.
+2. THE documentation SHALL include a code example showing the correct way to consume a Keypair_Utility via Dynamic_Import.
+3. THE documentation SHALL include a code example showing an incorrect Static_Import and explain why it violates the isolation contract.
+4. THE documentation SHALL describe how to run the Bundle_Checker locally and how to interpret the Exclusion_Assertion output.
+5. WHEN a new cryptographic library is added to the project, THE developer SHALL update the documentation to list the new library and its intended use case.

--- a/.kiro/specs/crypto-bundle-isolation/tasks.md
+++ b/.kiro/specs/crypto-bundle-isolation/tasks.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Crypto Bundle Isolation
+
+## Overview
+
+Implement crypto bundle isolation by creating a dedicated `Crypto_Wrapper` module, a `Lazy_Crypto_Page` route, a `CryptoToolsPanel` UI component, and extending the bundle checker with `Exclusion_Assertion` logic. Dependencies (`stellar-sdk`, `tweetnacl`) are added as pinned production dependencies. The main dashboard bundle must never contain any cryptographic library identifiers.
+
+## Tasks
+
+- [ ] 1. Add pinned crypto dependencies and configure `.bundle-limits.json`
+  - [ ] 1.1 Add `stellar-sdk@12.3.0` and `tweetnacl@1.0.3` as pinned production dependencies in `package.json`
+    - Add both packages under `"dependencies"` with exact versions (no `^` or `~`)
+    - _Requirements: 1.1, 1.4, 2.1_
+
+  - [ ] 1.2 Extend `.bundle-limits.json` with crypto isolation fields
+    - Add `"cryptoIsolation": true`, `"cryptoWrapperChunkWarningKb": 150`, and `"forbiddenInMainBundle"` array containing `"stellar-sdk"`, `"stellar_sdk"`, `"tweetnacl"`, `"@noble/ed25519"`, `"noble/ed25519"`, `"keypairUtils"`
+    - _Requirements: 4.1, 5.1, 5.4_
+
+- [ ] 2. Create the Crypto_Wrapper module
+  - [ ] 2.1 Create `src/lib/crypto/keypairUtils.ts` with all exported keypair utility functions
+    - Implement `generateKeypair()`, `keypairFromSecret()`, `signPayload()`, and `verifySignature()` exactly as specified in the design
+    - Static imports of `stellar-sdk` and `tweetnacl` must appear only in this file
+    - No top-level side effects — no key generation at module evaluation time
+    - All error messages must name the failing library (`stellar-sdk`, `tweetnacl`)
+    - Export `GeneratedKeypair`, `SignResult`, and `VerifyResult` interfaces
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [ ]* 2.2 Write unit tests for `keypairUtils.ts`
+    - Test `generateKeypair()` returns a valid Stellar public key (starts with `G`) and secret key (starts with `S`)
+    - Test `keypairFromSecret()` round-trips correctly and throws a descriptive error on a malformed secret
+    - Test `signPayload()` produces a hex string and `verifySignature()` returns `{ valid: true }` for a matching pair
+    - Test `verifySignature()` returns `{ valid: false }` for a tampered message
+    - _Requirements: 1.3, 1.4_
+
+- [ ] 3. Checkpoint — Crypto_Wrapper baseline
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Create the CryptoToolsPanel UI component
+  - [ ] 4.1 Create `src/app/components/crypto/CryptoToolsPanel.tsx`
+    - Implement the full panel with keypair generation section and sign/verify section as specified in the design
+    - Use a runtime `async function loadCrypto()` (not a static top-level import) to load `keypairUtils`
+    - Render a `role="alert"` error div when any crypto operation throws
+    - Use `aria-labelledby` on each `<section>` for accessibility
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.4_
+
+  - [ ]* 4.2 Write unit tests for `CryptoToolsPanel`
+    - Mock `loadCrypto` to return stub implementations
+    - Test that clicking "Generate Keypair" calls `generateKeypair` and renders the public/secret key output
+    - Test that a rejected `loadCrypto` promise renders the `role="alert"` error element
+    - _Requirements: 2.2, 2.4_
+
+- [ ] 5. Create the Lazy_Crypto_Page route
+  - [ ] 5.1 Create `src/app/crypto-tools/page.tsx`
+    - Mark the file with `'use client'`
+    - Import `CryptoToolsPanel` via `next/dynamic` with `ssr: false`
+    - Provide a `loading` fallback with `role="status"` and `aria-label="Loading cryptographic tools"` as specified in the design
+    - Render a `<main>` wrapper with the page heading and `<CryptoToolsPanel />`
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [ ]* 5.2 Write unit tests for `CryptoToolsPage`
+    - Mock `next/dynamic` to verify `ssr: false` is passed
+    - Test that the loading fallback renders while the dynamic import is pending
+    - _Requirements: 3.2, 3.3_
+
+- [ ] 6. Checkpoint — UI layer complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 7. Extend `scripts/check-bundle-size.js` with Exclusion_Assertion
+  - [ ] 7.1 Add `runCryptoExclusionAssertion(report, limits, jsDir, files)` function to `check-bundle-size.js`
+    - Implement the function exactly as specified in the design: scan `main-*` chunks for each identifier in `limits.forbiddenInMainBundle`, populate `report.cryptoIsolation.cryptoExclusionViolations`, detect the crypto wrapper chunk by filename pattern, emit a non-blocking warning when the chunk exceeds `cryptoWrapperChunkWarningKb`
+    - Call `runCryptoExclusionAssertion` inside `analyzeBundles()` after the existing per-file loop
+    - Emit `🔐 Crypto isolation verified` on success and `❌ Crypto isolation FAILED` with violation details on failure
+    - _Requirements: 4.1, 4.2, 4.3, 4.5, 5.3, 5.4_
+
+  - [ ]* 7.2 Write unit tests for `runCryptoExclusionAssertion`
+    - Test that a `main-*.js` file containing `"stellar-sdk"` produces a violation entry and sets `report.passed = false`
+    - Test that a `main-*.js` file with no forbidden identifiers sets `report.cryptoIsolation.verified = true`
+    - Test that a non-main chunk containing a forbidden identifier does NOT produce a violation
+    - Test that a chunk named `crypto-keypairUtils-xyz.js` is identified as the wrapper chunk and its gzipped size is recorded
+    - _Requirements: 4.1, 4.2, 4.3, 4.5, 5.3_
+
+- [ ] 8. Extend `.github/workflows/bundle-check.yml` PR comment with crypto isolation status
+  - [ ] 8.1 Update the `Comment PR with bundle report` step in `bundle-check.yml` to surface crypto isolation status
+    - After the existing violations block, add the `if (report.cryptoIsolation)` block from the design: render `🔐 Crypto isolation: ✅ verified` or `❌ FAILED`, list the crypto wrapper chunk name and gzipped size, and list any `cryptoExclusionViolations`
+    - _Requirements: 4.4, 5.3_
+
+- [ ] 9. Create developer documentation
+  - [ ] 9.1 Create `docs/CRYPTO_BUNDLE_ISOLATION.md`
+    - Describe the Crypto_Wrapper pattern, the Lazy_Crypto_Page route, and the Exclusion_Assertion checks
+    - Include a correct code example showing Dynamic_Import consumption of a Keypair_Utility
+    - Include an incorrect Static_Import example with an explanation of why it violates isolation
+    - Describe how to run the Bundle_Checker locally (`npm run build` / `npm run build:strict`) and how to interpret the Exclusion_Assertion output in `.bundle-report.json`
+    - Include a section on how to add a new cryptographic library (update Crypto_Wrapper, update `forbiddenInMainBundle`, update this doc)
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+
+- [ ] 10. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Tasks 7 and 8 (bundle checker + CI) are independent of tasks 4 and 5 (UI) and can be executed in parallel
+- Task 9 (documentation) is last by design — it documents the completed system
+- `src/app/logs/xdr-worker.ts`, `src/app/page.tsx`, and `src/app/layout.tsx` must NOT be modified
+- The Crypto_Wrapper (`keypairUtils.ts`) is the only file in `src/` permitted to statically import `stellar-sdk` or `tweetnacl`
+- Property-based tests are not applicable here — the design has no Correctness Properties section; unit tests cover the relevant invariants
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["2.2", "4.1", "7.1"] },
+    { "id": 3, "tasks": ["4.2", "5.1", "7.2"] },
+    { "id": 4, "tasks": ["5.2", "8.1"] },
+    { "id": 5, "tasks": ["9.1"] }
+  ]
+}
+```


### PR DESCRIPTION
Close: #305 
 Here's a summary of what was created:

.kiro/specs/crypto-bundle-isolation/

requirements.md — 7 requirements covering the Crypto_Wrapper, dynamic import enforcement, the lazy page route, exclusion assertions, bundle regression guard, XDR worker non-interference, and developer docs
design.md — full technical design grounded in the project's existing Next.js App Router, TypeScript, and bundle checker conventions
tasks.md — 10 top-level tasks (14 sub-tasks) with a dependency graph
Execution order:

Add stellar-sdk@12.3.0 + tweetnacl@1.0.3 to package.json, extend .bundle-limits.json
Create 
keypairUtils.ts
 (the sole static importer of crypto libs)
Create CryptoToolsPanel.tsx + 
page.tsx
 (UI layer, parallel with…)
Extend check-bundle-size.js with runCryptoExclusionAssertion() + update the CI workflow
Write 
CRYPTO_BUNDLE_ISOLATION.md
Say "run tasks" whenever you're ready to execute the implementation.