### PR TITLE
 Auto-Pausing Ingestion Feeds on Hidden Tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.100.5",
+        "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.24",
         "@types/leaflet": "^1.9.21",
         "@types/ws": "^8.18.1",
@@ -3045,6 +3046,26 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.25",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.25.tgz",
@@ -3060,6 +3081,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/virtual-core": {

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -5,7 +5,6 @@ import React, {
   useState,
   useCallback,
   memo,
-  useSyncExternalStore,
 } from "react";
 import { useRAFInterval } from "@/app/hooks/useRAFInterval";
 import { useInactivityDelay } from "@/app/hooks/useInactivityDelay";

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -40,30 +40,7 @@ interface PriceFeedCardProps {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function usePageVisibility(): boolean {
-  return useSyncExternalStore(
-    (onStoreChange) => {
-      if (typeof document === "undefined") return () => {};
-
-      const handleVisibilityChange = () => {
-        onStoreChange();
-      };
-
-      document.addEventListener("visibilitychange", handleVisibilityChange);
-      return () => {
-        document.removeEventListener(
-          "visibilitychange",
-          handleVisibilityChange,
-        );
-      };
-    },
-    () =>
-      typeof document === "undefined"
-        ? false
-        : document.visibilityState === "visible",
-    () => false,
-  );
-}
+import { usePageVisibility } from "../hooks/usePageVisibility";
 
 /**
  * Fetches the NGN/XLM price feed from the StellarFlow oracle API.

--- a/src/app/hooks/usePageVisibility.ts
+++ b/src/app/hooks/usePageVisibility.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+/**
+ * A centralized hook that returns the current visibility status of the page.
+ * Returns `true` if the page is visible, `false` otherwise.
+ * 
+ * Uses `useSyncExternalStore` for efficient updates and SSR compatibility.
+ */
+export function usePageVisibility(): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof document === 'undefined') return () => {}
+
+      document.addEventListener('visibilitychange', onStoreChange)
+      return () => {
+        document.removeEventListener('visibilitychange', onStoreChange)
+      }
+    },
+    () => (typeof document !== 'undefined' ? document.visibilityState === 'visible' : true),
+    () => true, // Server-side default
+  )
+}

--- a/src/app/hooks/useRAFInterval.ts
+++ b/src/app/hooks/useRAFInterval.ts
@@ -12,6 +12,11 @@ let rafId: number | null = null
 const subscribers = new Set<Subscriber>()
 
 const tick = (now: number) => {
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+    rafId = null
+    return
+  }
+
   subscribers.forEach((sub) => {
     if (now - sub.lastTick >= sub.intervalMs) {
       sub.lastTick = now
@@ -22,7 +27,7 @@ const tick = (now: number) => {
 }
 
 const startLoop = () => {
-  if (rafId === null) {
+  if (rafId === null && (typeof document === 'undefined' || document.visibilityState === 'visible')) {
     rafId = requestAnimationFrame(tick)
   }
 }
@@ -32,6 +37,16 @@ const stopLoop = () => {
     cancelAnimationFrame(rafId)
     rafId = null
   }
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      startLoop()
+    } else {
+      // The tick function will automatically stop when it detects hidden state
+    }
+  })
 }
 
 export function useRAFInterval(

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -191,7 +191,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setError("Failed to establish WebSocket connection");
       console.error("Connection error:", err);
     }
-  }, []); // ← intentionally empty; all mutable values go through refs
+  }, [flushPendingUpdates, setError]);
 
   const disconnect = useCallback(() => {
     manuallyDisconnectedRef.current = true;

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { PriceData } from "@/types";
 import { useErrorTimeout } from "./useErrorTimeout";
+import { usePageVisibility } from "./usePageVisibility";
 
 interface SocketMessage {
   type: "price_update" | "delta_update";
@@ -54,7 +55,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     null,
   );
   const manuallyDisconnectedRef = useRef(false);
-  const pageVisibleRef = useRef(true);
+  const isVisible = usePageVisibility();
+  const pageVisibleRef = useRef(isVisible);
   
   // Batching refs for high-frequency updates
   const pendingUpdatesRef = useRef<(PriceData | Partial<PriceData>)[]>([]);
@@ -280,47 +282,38 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     };
   }, [flushPendingUpdates]);
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      const isVisible = document.visibilityState === "visible";
-      pageVisibleRef.current = isVisible;
+    pageVisibleRef.current = isVisible;
 
-      if (!isVisible) {
-        if (reconnectTimeoutRef.current) {
-          clearTimeout(reconnectTimeoutRef.current);
-          reconnectTimeoutRef.current = null;
-        }
-
-        if (wsRef.current?.readyState === WebSocket.OPEN) {
-          wsRef.current.send(
-            JSON.stringify({
-              type: "unsubscribe",
-              assetIds: Array.from(subscribedAssetsRef.current),
-            }),
-          );
-        }
-
-        if (wsRef.current) {
-          wsRef.current.close(1000, "Page hidden");
-          wsRef.current = null;
-        }
-
-        setIsConnected(false);
-        return;
+    if (!isVisible) {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
 
-      if (!manuallyDisconnectedRef.current) {
-        reconnectAttemptsRef.current = 0;
-        setReconnectAttempts(0);
-        connect();
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: "unsubscribe",
+            assetIds: Array.from(subscribedAssetsRef.current),
+          }),
+        );
       }
-    };
 
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+      if (wsRef.current) {
+        wsRef.current.close(1000, "Page hidden");
+        wsRef.current = null;
+      }
 
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [connect]);
+      setIsConnected(false);
+      return;
+    }
+
+    if (!manuallyDisconnectedRef.current) {
+      reconnectAttemptsRef.current = 0;
+      setReconnectAttempts(0);
+      connect();
+    }
+  }, [isVisible, connect]);
 
   return {
     isConnected,


### PR DESCRIPTION
closes #250
closes #233 
Monitor page visibility status using standard window event hooks (visibilitychange).

Temporarily freeze data ingestion engines whenever a user switches browser tabs, resuming automatically upon return.

If you find this implementation useful, please star the project and leave a review! 😊