### PR TITLE
Compacting Disjointed Micro-State Modification Dispatches

### DIFF
--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -168,28 +168,24 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
 
     if (!wsUpdate || !enableWebSocket || !isPageVisible) return;
 
-    const frameId = window.requestAnimationFrame(() => {
-      setData((prev: PriceFeedData | null) => ({
-        price: wsUpdate.price || prev?.price || 0,
-        // Reset 24 h change indicator when a fresh price arrives.
-        change_24h: wsUpdate.price ? 0 : prev?.change_24h || 0,
-        high_24h: wsUpdate.price
-          ? Math.max(wsUpdate.price, prev?.high_24h || 0)
-          : prev?.high_24h || 0,
-        low_24h: wsUpdate.price
-          ? Math.min(wsUpdate.price, prev?.low_24h || Infinity)
-          : prev?.low_24h || 0,
-        volume_24h: prev?.volume_24h || 0, // volume comes from REST, not WS
-        last_updated: wsUpdate.timestamp
-          ? new Date(wsUpdate.timestamp).toISOString()
-          : prev?.last_updated || new Date().toISOString(),
-      }));
-      setLastRefresh(new Date());
-      setLoading(false);
-      setError(null);
-    });
-
-    return () => window.cancelAnimationFrame(frameId);
+    setData((prev: PriceFeedData | null) => ({
+      price: wsUpdate.price || prev?.price || 0,
+      // Reset 24 h change indicator when a fresh price arrives.
+      change_24h: wsUpdate.price ? 0 : prev?.change_24h || 0,
+      high_24h: wsUpdate.price
+        ? Math.max(wsUpdate.price, prev?.high_24h || 0)
+        : prev?.high_24h || 0,
+      low_24h: wsUpdate.price
+        ? Math.min(wsUpdate.price, prev?.low_24h || Infinity)
+        : prev?.low_24h || 0,
+      volume_24h: prev?.volume_24h || 0, // volume comes from REST, not WS
+      last_updated: wsUpdate.timestamp
+        ? new Date(wsUpdate.timestamp).toISOString()
+        : prev?.last_updated || new Date().toISOString(),
+    }));
+    setLastRefresh(new Date());
+    setLoading(false);
+    setError(null);
   }, [wsUpdate, enableWebSocket, isPageVisible, mounted, setError]); // `data` intentionally omitted — accessed via functional updater
 
   // Handle WebSocket errors

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { PriceData } from "@/types";
 import { useErrorTimeout } from "./useErrorTimeout";
 import { usePageVisibility } from "./usePageVisibility";
+import { useRAFInterval } from "./useRAFInterval";
 
 interface SocketMessage {
   type: "price_update" | "delta_update";
@@ -60,7 +61,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   
   // Batching refs for high-frequency updates
   const pendingUpdatesRef = useRef<(PriceData | Partial<PriceData>)[]>([]);
-  const flushIntervalRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Refs keep options fresh inside callbacks without triggering re-renders or
   // causing `connect` to be recreated on every tick.
@@ -125,9 +125,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         reconnectAttemptsRef.current = 0;
         setReconnectAttempts(0);
 
-        // Start the flush interval when connected
-        flushIntervalRef.current = setInterval(flushPendingUpdates, 350);
-
         if (subscribedAssetsRef.current.size > 0) {
           wsRef.current?.send(
             JSON.stringify({
@@ -159,12 +156,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       wsRef.current.onclose = (event: CloseEvent) => {
         setIsConnected(false);
 
-        // Clean up flush interval on close
-        if (flushIntervalRef.current) {
-          clearInterval(flushIntervalRef.current);
-          flushIntervalRef.current = null;
-        }
-
         // Flush any remaining pending updates
         flushPendingUpdates();
 
@@ -195,12 +186,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
   const disconnect = useCallback(() => {
     manuallyDisconnectedRef.current = true;
-
-    // Clean up flush interval
-    if (flushIntervalRef.current) {
-      clearInterval(flushIntervalRef.current);
-      flushIntervalRef.current = null;
-    }
 
     // Flush any remaining pending updates
     flushPendingUpdates();
@@ -263,11 +248,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // effect above runs in strict-mode double-invocation.
   useEffect(() => {
     return () => {
-      // Clean up flush interval on unmount
-      if (flushIntervalRef.current) {
-        clearInterval(flushIntervalRef.current);
-        flushIntervalRef.current = null;
-      }
 
       // Flush any remaining pending updates
       flushPendingUpdates();
@@ -314,6 +294,14 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       connect();
     }
   }, [isVisible, connect]);
+
+  // Master layout clock batching: flushes updates inline with the single RAF loop
+  // every 350ms whenever the connection is alive and there are pending packets.
+  useRAFInterval(
+    flushPendingUpdates,
+    350,
+    isConnected
+  );
 
   return {
     isConnected,


### PR DESCRIPTION
Close: #372
Store-Batching: Compacting Disjointed Micro-State Modification Dispatches
I have completed the task to centralise the layout clock, ensuring state dispatches from high-frequency metric feeds are batched properly instead of fragmented across individual disjointed timers. This will drastically minimise layout reflows and browser thrashing.

Changes Implemented
useSocket.ts

Swapped out the old manual batch-flushing technique (using setInterval natively).
Hooked up flushPendingUpdates to 
useRAFInterval
 so that the socket updates now intrinsically fire on the unified master timer tracked inside a requestAnimationFrame loop.
Removed stale cleanup lifecycle bounds associated with the legacy interval.
PriceFeedCard.tsx

Removed the nested, redundant local requestAnimationFrame wrap from the dynamic socket data dispatch pipeline. Since wsUpdate dispatches from 
useSocket
 have already been globally batched natively on the layout clock, we can afford immediate execution (setData).