### PR TITLE
refactor: replace xdrWorker stub with re-export to canonical worker

### DIFF
--- a/src/app/workers/xdrWorker.ts
+++ b/src/app/workers/xdrWorker.ts
@@ -1,19 +1,5 @@
-"use client";
-
-// src/app/workers/xdrWorker.ts
-// Minimal Web Worker to parse base64‑encoded Soroban XDR logs.
-// In a real implementation you would import the @stellar/stellar‑sdk XDR parser.
-// Here we simply decode base64 and wrap it in an object for demonstration.
-
-self.addEventListener('message', (event: MessageEvent) => {
-  const { id, payload } = event.data;
-  try {
-    // Decode base64 string – placeholder for real XDR parsing.
-    const decoded = atob(payload);
-    // Simulate parsed structure.
-    const result = { id, parsed: decoded };
-    self.postMessage({ id, result });
-  } catch (error) {
-    self.postMessage({ id, error: (error as Error).message });
-  }
-});
+// Re-export the canonical XDR worker hook from its co-located module.
+// The actual Web Worker script lives at: src/app/logs/xdr-worker.ts
+// The React hook that spawns it lives at: src/app/logs/useXdrWorker.ts
+export { useXdrWorker } from '../logs/useXdrWorker';
+export type { BatchDecodeResult, DecodeXdrPayload, XdrFields } from '../logs/worker-types';


### PR DESCRIPTION
The src/app/workers/xdrWorker.ts file was an orphaned stub with
  two problems: it carried an invalid "use client" directive
  (meaningless in a Worker scope) and contained a trivial atob
  placeholder that had already been superseded by the full
  implementation in src/app/logs/.
  
  This PR removes the stub and replaces it with a clean re-export
  pointing to the canonical modules:
  
  - useXdrWorker hook → src/app/logs/useXdrWorker.ts
  - Types (BatchDecodeResult, DecodeXdrPayload, XdrFields) →
  src/app/logs/worker-types.ts
  
  The actual background thread logic is unchanged — the worker
  spawned via new Worker(new URL('./xdr-worker.ts',
  import.meta.url)) continues to handle DECODE_XDR and
  BATCH_DECODE messages on an isolated thread, keeping XDR log
  parsing off the main UI render loop.
  
  Files changed: src/app/workers/xdrWorker.ts

closes #355