### PR TITLE
Inject passive scrolling attributes to logging windows (#371)

### DIFF
--- a/src/app/components/DashboardTrafficChart.tsx
+++ b/src/app/components/DashboardTrafficChart.tsx
@@ -152,10 +152,10 @@ export default function DashboardTrafficChart({
     };
 
     const canvas = canvasRef.current;
-    canvas.addEventListener("pointermove", handlePointerMove);
-    canvas.addEventListener("pointerleave", hideTooltip);
-    canvas.addEventListener("pointerout", hideTooltip);
-    canvas.addEventListener("pointercancel", hideTooltip);
+    canvas.addEventListener("pointermove", handlePointerMove, { passive: true });
+    canvas.addEventListener("pointerleave", hideTooltip, { passive: true });
+    canvas.addEventListener("pointerout", hideTooltip, { passive: true });
+    canvas.addEventListener("pointercancel", hideTooltip, { passive: true });
 
     return () => {
       canvas.removeEventListener("pointermove", handlePointerMove);


### PR DESCRIPTION
**Summary**

Adds `{ passive: true }` to the four pointer-event `addEventListener` calls in `DashboardTrafficChart.tsx` for consistency with the existing pattern in `useInactivityDelay.ts`.

**Audit of scroll/touch/wheel listeners across the codebase**

| Location | Listener type | Passive? | Notes |
|---|---|---|---|
| `useInactivityDelay.ts:106` | `touchstart`, `scroll`, `wheel` | ✅ Already `{ passive: true }` | Handler is throttled (500ms), no `preventDefault` |
| `logs/page.tsx` | — | ✅ N/A | Scrolling handled by `@tanstack/react-virtual` (sets passive listeners internally) |
| `DashboardTrafficChart.tsx` | `pointermove`, `pointerleave`, `pointerout`, `pointercancel` | ✅ Now `{ passive: true }` | Canvas tooltip interaction, no `preventDefault` |

**No `wheel`, `touchstart`, `touchmove`, `touchcancel`, `touchend`, or `trackbar` event listeners exist elsewhere in the codebase.

**Why passive listeners**
Without `{ passive: true }`, the browser must wait for every handler to complete before compositing the scroll frame (in case it calls `preventDefault`). The passive flag eliminates this serialization, eliminating scroll jank.

**Closes #371**