### PR TITLE
#398 🧠 Hook-Tuning | Isolating State Intercept Triggers inside Window Watchers

### DIFF
--- a/src/app/hooks/useWindowSize.ts
+++ b/src/app/hooks/useWindowSize.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRafThrottle } from "./useRafThrottle";
+
+export interface WindowSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * useWindowSize
+ * 
+ * Hook-Tuning | Isolating State Intercept Triggers inside Window Watchers
+ * 
+ * Triggering layout updates on every individual window resize pixel shift overloads 
+ * component state, leading to noticeable interface lag. This hook wraps window 
+ * resize tracking loops within a tight execution throttle window handler, and 
+ * updates structural values only after resize interactions settle to protect 
+ * component performance.
+ */
+export function useWindowSize(settleDelay = 150): WindowSize {
+  const [size, setSize] = useState<WindowSize>({
+    width: typeof window !== "undefined" ? window.innerWidth : 0,
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Wrap window resize tracking loops within a tight execution throttle window handler.
+  const throttledResizeHandler = useRafThrottle(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    
+    // Update structural values only after resize interactions settle
+    timerRef.current = setTimeout(() => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+      timerRef.current = null;
+    }, settleDelay);
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    window.addEventListener("resize", throttledResizeHandler, { passive: true });
+    
+    // Set initial size without delay
+    setSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+
+    return () => {
+      window.removeEventListener("resize", throttledResizeHandler);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [throttledResizeHandler, settleDelay]);
+
+  return size;
+}


### PR DESCRIPTION
## Summary  #398 

Optimizes window resize handling by throttling resize event listeners and delaying layout state updates until resize activity settles. This reduces unnecessary re-renders, improves UI responsiveness, and prevents performance issues caused by frequent state updates during continuous window resizing.

Closes #398 

## Checklist

* [ ] `make test` passes locally
* [ ] `make lint` and `make format` are clean
* [ ] New/changed behavior has test coverage
* [ ] `CHANGELOG.md` updated under "Unreleased"
* [ ] If a shared contract changed (`RiskScore`, asset pair format, feature schema), linked issues/PRs in `ledgerlens-core` and downstream repos
