### PR TITLE
Configure SWC compiler to strip debug logs from production builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,11 @@ const withPwaConfig = withPWA({
 const nextConfig: NextConfig = {
   reactCompiler: false,
   compress: true,
+  compiler: {
+    removeConsole: {
+      exclude: ["error", "warn"],
+    },
+  },
   productionBrowserSourceMaps: false,
   turbopack: {},
   images: {


### PR DESCRIPTION
Add compiler.removeConsole option in next.config.ts to automatically remove console.log, console.debug, and console.info calls during production build minification, while preserving console.error and console.warn for critical diagnostics.

This reduces production bundle footprints and prevents internal system paths from being exposed in compiled assets.

# closes #395