### PR TITLE
refactor: consolidate ballot timers into a single requestAnimationFra…

### DIFF
--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { 
   Vote, 
   FilePlus, 
@@ -13,8 +13,9 @@ import {
   ChevronRight, 
   Wallet 
 } from 'lucide-react';
+import { subscribe } from '@/workers/masterTimerWorker';
 import { withShortenedAddressField } from '@/utils/addressUtils';
-import { useRAFInterval } from '@/app/hooks/useRAFInterval';
+
 import { useWallet, useWalletStatus, useWalletActions } from '@/app/hooks/useWalletState';
 import { Icon, ICON_IDS } from '@/components/icons';
 
@@ -93,15 +94,19 @@ export default function GovernancePage() {
     () => Object.fromEntries(MOCK_PROPOSALS.map(p => [p.id, p.endsInLedgers]))
   );
 
-  useRAFInterval(() => {
-    setLedgerCounts(prev => {
-      const next = { ...prev };
-      for (const id in next) {
-        if (next[id] > 0) next[id] -= 1;
-      }
-      return next;
+  // Subscribe to the central master timer (via requestAnimationFrame) to decrement ledger counts.
+  useEffect(() => {
+    const unsubscribe = subscribe(() => {
+      setLedgerCounts(prev => {
+        const next = { ...prev };
+        for (const id in next) {
+          if (next[id] > 0) next[id] -= 1;
+        }
+        return next;
+      });
     });
-  }, 5000);
+    return () => unsubscribe();
+  }, []);
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-gray-100 p-8">

--- a/src/workers/masterTimerWorker.ts
+++ b/src/workers/masterTimerWorker.ts
@@ -1,0 +1,48 @@
+/* src/workers/masterTimerWorker.ts */
+
+type Callback = () => void;
+
+const subscribers = new Set<Callback>();
+let running = false;
+
+function tick() {
+  // Execute all subscriber callbacks on each animation frame.
+  subscribers.forEach((cb) => {
+    try {
+      cb();
+    } catch (e) {
+      console.error('masterTimerWorker callback error', e);
+    }
+  });
+  requestAnimationFrame(tick);
+}
+
+/**
+ * Starts the RAF loop if not already started. This is invoked automatically on first subscription.
+ */
+function start() {
+  if (!running) {
+    running = true;
+    requestAnimationFrame(tick);
+  }
+}
+
+/**
+ * Subscribe to the central timer. The provided callback will be called on every animation frame.
+ * The function returns an unsubscribe function to remove the callback.
+ */
+export function subscribe(cb: Callback): () => void {
+  subscribers.add(cb);
+  start();
+  return () => {
+    subscribers.delete(cb);
+  };
+}
+
+// Export for convenience if direct start is needed.
+export { start };
+
+export default {
+  subscribe,
+  start,
+};


### PR DESCRIPTION
This pr closes #373

Description
Running multiple concurrent background timers to track ballot expiration deadlines wastes CPU performance metrics. This PR refactors the timing architecture by centralizing all polling ticks under a single requestAnimationFrame loop.

Proposed Changes
New central timer worker: Created src/workers/masterTimerWorker.ts which manages a single requestAnimationFrame tick loop and processes a set of subscribers.
Centralized subscription logic: Removed the item‑specific useRAFInterval ticks in src/app/governance/page.tsx and replaced them with a subscription to the centralized master timer worker, which automatically unsubscribes on component unmount to prevent memory leaks.