### PR TITLE
fix: prune trailing interval timers and active socket pipelines on view change

### DIFF
--- a/src/app/consumers/page.tsx
+++ b/src/app/consumers/page.tsx
@@ -88,9 +88,20 @@ export default function ConsumersPage() {
     );
   }, [debouncedSearch, transformedConsumers]);
 
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
   const handleCopy = () => {
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -23,6 +23,15 @@ export default function DocsPage() {
   const [invoking, setInvoking] = useState(false);
   const [invokeResult, setInvokeResult] = useState<string | null>(null);
 
+  const timeoutsRef = React.useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  useEffect(() => {
+    return () => {
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current.clear();
+    };
+  }, []);
+
   useEffect(() => {
     // ensure runtime cache is populated once (fast path avoids repeated parsing)
     if (typeof window !== 'undefined') {
@@ -38,7 +47,11 @@ export default function DocsPage() {
     try {
       navigator.clipboard.writeText(text);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      const timer = setTimeout(() => {
+        setCopied(false);
+        timeoutsRef.current.delete(timer);
+      }, 2000);
+      timeoutsRef.current.add(timer);
     } catch (e) {
       // noop
     }
@@ -47,7 +60,7 @@ export default function DocsPage() {
   const handleTestInvoke = () => {
     setInvoking(true);
     setInvokeResult(null);
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setInvoking(false);
       setInvokeResult(
         JSON.stringify({
@@ -62,7 +75,9 @@ export default function DocsPage() {
           }
         }, null, 2)
       );
+      timeoutsRef.current.delete(timer);
     }, 1200);
+    timeoutsRef.current.add(timer);
   };
 
   return (

--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -170,7 +170,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
           reconnectAttemptsRef.current += 1;
           setReconnectAttempts(reconnectAttemptsRef.current);
           reconnectTimeoutRef.current = setTimeout(() => {
-            doConnect();
+            if (subscribedAssetsRef.current.size > 0) {
+              doConnect();
+            }
           }, reconnectIntervalRef.current);
         }
       };
@@ -209,7 +211,19 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     manuallyDisconnectedRef.current = false;
     reconnectAttemptsRef.current = 0;
     setReconnectAttempts(0);
-    setTimeout(connect, 100);
+    
+    // Clear any existing reconnect timeout
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+    }
+    
+    // Set new reconnect timeout and track it
+    reconnectTimeoutRef.current = setTimeout(() => {
+      reconnectTimeoutRef.current = null;
+      if (subscribedAssetsRef.current.size > 0) {
+        connect();
+      }
+    }, 100);
   }, [disconnect, connect]);
 
   const subscribeToAsset = useCallback((assetId: string) => {
@@ -220,9 +234,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         wsRef.current.send(
           JSON.stringify({ type: "subscribe", assetIds: [assetId] }),
         );
+      } else if (!wsRef.current) {
+        connect();
       }
     }
-  }, []);
+  }, [connect]);
 
   const unsubscribeFromAsset = useCallback((assetId: string) => {
     if (subscribedAssetsRef.current.has(assetId)) {
@@ -233,13 +249,19 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
           JSON.stringify({ type: "unsubscribe", assetIds: [assetId] }),
         );
       }
+
+      if (subscribedAssetsRef.current.size === 0) {
+        disconnect();
+      }
     }
-  }, []);
+  }, [disconnect]);
 
   // Both `connect` and `disconnect` are now stable (empty dep arrays), so this
   // effect only runs once on mount and once on unmount — never on data ticks.
   useEffect(() => {
-    connect();
+    if (subscribedAssetsRef.current.size > 0) {
+      connect();
+    }
     return () => {
       disconnect();
     };
@@ -292,7 +314,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     if (!manuallyDisconnectedRef.current) {
       reconnectAttemptsRef.current = 0;
       setReconnectAttempts(0);
-      connect();
+      if (subscribedAssetsRef.current.size > 0) {
+        connect();
+      }
     }
   }, [isVisible, connect]);
 

--- a/src/app/staking/page.tsx
+++ b/src/app/staking/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useDebounce } from '../hooks/useDebounce';
 import { useRafThrottle } from '../hooks/useRafThrottle';
 import { useTransformedCustomAddressField } from '@/app/hooks/useTransformedData';
@@ -43,6 +43,15 @@ export default function StakingPage() {
   const [confirmationMsg, setConfirmationMsg] = useState<string | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  useEffect(() => {
+    return () => {
+      // Explicitly cleanup trailing timers on unmount
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current.clear();
+    };
+  }, []);
 
   const handleConfirm = useCallback(async (allocations: Record<string, number>) => {
     if (isSubmitting) return;
@@ -53,10 +62,19 @@ export default function StakingPage() {
       setConfirmationMsg('Allocation confirmed. Submitting to network…');
       const txHash = await submitTransaction(allocations);
       setConfirmationMsg(`Transaction successful: ${txHash}`);
-      setTimeout(() => setConfirmationMsg(null), 3000);
+      
+      const timer1 = setTimeout(() => {
+        setConfirmationMsg(null);
+        timeoutsRef.current.delete(timer1);
+      }, 3000);
+      timeoutsRef.current.add(timer1);
     } catch (err) {
       setConfirmationMsg('Transaction failed');
-      setTimeout(() => setConfirmationMsg(null), 2000);
+      const timer2 = setTimeout(() => {
+        setConfirmationMsg(null);
+        timeoutsRef.current.delete(timer2);
+      }, 2000);
+      timeoutsRef.current.add(timer2);
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
closes #357 


## Summary of Changes
- **WebSocket Connection Pruning**: Updated the `useSocket` layout state hook to lazily bind WebSocket connections and explicitly tear down active pipelines when subscriber volume hits `0`.
- **Untracked Timeout Fix**: Patched edge cases in `useSocket` where manual reconnections and visibility changes could bypass original cleanup routines.
- **Trailing UI Timers**: Applied `useRef` tracked state bounds and explicit `useEffect` cleanup operations to `setTimeout` calls within `staking`, `docs`, and `consumers` view components.

## Reason for the Changes
**Fixes Issue #357** 
Failing to explicitly close active WebSocket pipelines or disconnect background timers when a user navigated away from monitor views (such as `DashboardInteractive`) was triggering permanent memory leaks. By establishing strict lifecycle returns, these components now clean up their memory footprint automatically, reducing baseline overhead significantly.


