### PR TITLE
perf: implement centralized in-flight promise pool to deduplicate API…

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -4,15 +4,38 @@ import { getFetchCacheOptions, REVALIDATE_INTERVALS } from '@/config/cacheConfig
  * API service layer with enforced cache re-validation periods.
  * All endpoints implement minimum 5-second revalidation to prevent backend flooding.
  */
+// Centralized In-Flight Request Pool (Deduplication)
+// Intercepts parallel requests for the exact same URL and serves them from a single promise
+const inFlightRequests = new Map<string, Promise<any>>();
+
+async function pooledFetch(url: string, options?: RequestInit) {
+  if (inFlightRequests.has(url)) {
+    return inFlightRequests.get(url);
+  }
+
+  const requestPromise = (async () => {
+    const res = await fetch(url, options);
+    if (!res.ok) throw new Error(`Failed to fetch ${url}`);
+    return res.json();
+  })();
+
+  inFlightRequests.set(url, requestPromise);
+
+  try {
+    return await requestPromise;
+  } finally {
+    // Clear from pool once resolved so subsequent requests trigger a fresh fetch
+    inFlightRequests.delete(url);
+  }
+}
+
 export const api = {
   /**
    * Fetches current price data with 10-second cache.
    * Prevents excessive requests to price data endpoints during high activity.
    */
   async getPrices() {
-    const res = await fetch('/api/prices', getFetchCacheOptions('SHORT_INTERVAL'))
-    if (!res.ok) throw new Error('Failed to fetch prices')
-    return res.json()
+    return pooledFetch('/api/prices', getFetchCacheOptions('SHORT_INTERVAL'))
   },
 
   /**
@@ -20,8 +43,6 @@ export const api = {
    * Reduces database queries for portfolio aggregations that change infrequently.
    */
   async getPortfolio() {
-    const res = await fetch('/api/portfolio', getFetchCacheOptions('MEDIUM_INTERVAL'))
-    if (!res.ok) throw new Error('Failed to fetch portfolio')
-    return res.json()
+    return pooledFetch('/api/portfolio', getFetchCacheOptions('MEDIUM_INTERVAL'))
   },
 }


### PR DESCRIPTION
… requests (Fixes #349)## Description
This PR resolves issue #349 by introducing a centralized request sharing pool to deduplicate parallel API calls. 

Although the original issue referenced the SWR config layer, this repository actively uses React Query. However, to guarantee absolute deduplication across the entire application—especially when multiple statistics cards mount simultaneously before cache population—the deduplication pool was implemented directly inside the `src/app/services/api.ts` layer.

## Changes Made
- **In-Flight Request Pool:** Created an `inFlightRequests` Map to track active network requests by URL.
- **`pooledFetch` Wrapper:** Implemented a promise interceptor. If a component requests data while an identical request is already in-flight, it attaches to the existing promise stream instead of triggering a redundant HTTP payload.
- **Service Integration:** Refactored `api.getPrices()` and `api.getPortfolio()` to utilize the shared `pooledFetch` utility, enforcing strict one-request-per-tick behavior.