### PR TITLE
fix(map): hard-lock regional network map dimensions to prevent CLS (#397)

### DIFF
--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -77,9 +77,9 @@ function Map() {
 
   if (loading) {
     return (
-      <div className="relative min-h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+      <div className="relative h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(217,249,157,0.12),transparent_35%),radial-gradient(circle_at_85%_80%,rgba(96,165,250,0.12),transparent_40%)]" />
-        <div className="relative flex h-full min-h-[280px] items-center justify-center rounded-[24px] border border-white/10 bg-[#0F172A] p-6 text-center">
+        <div className="relative flex h-[280px] items-center justify-center rounded-[24px] border border-white/10 bg-[#0F172A] p-6 text-center">
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[#D9F99D]/85">
               Loading Network Map...
@@ -95,9 +95,9 @@ function Map() {
 
   if (error) {
     return (
-      <div className="relative min-h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+      <div className="relative h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(217,249,157,0.12),transparent_35%),radial-gradient(circle_at_85%_80%,rgba(96,165,250,0.12),transparent_40%)]" />
-        <div className="relative flex h-full min-h-[280px] items-center justify-center rounded-[24px] border border-white/10 bg-[#0F172A] p-6 text-center">
+        <div className="relative flex h-[280px] items-center justify-center rounded-[24px] border border-white/10 bg-[#0F172A] p-6 text-center">
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.28em] text-red-400">
               Map Error
@@ -113,13 +113,13 @@ function Map() {
 
   return (
     <div
-      className="relative min-h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]"
+      className="relative h-[320px] overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]"
       // @ts-expect-error — fetchPriority is a valid HTML attribute but not yet in React types
       fetchPriority="high"
       data-lcp-element="network-map"
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(217,249,157,0.12),transparent_35%),radial-gradient(circle_at_85%_80%,rgba(96,165,250,0.12),transparent_40%)]" />
-      <div className="relative h-full min-h-[280px] rounded-[24px] border border-white/10 overflow-hidden">
+      <div className="relative h-[280px] rounded-[24px] border border-white/10 overflow-hidden">
         <div className="w-full h-full">
           <MapContainer
             center={[0, 20]} // Center on Africa

--- a/src/components/skeletons/MapSkeleton.tsx
+++ b/src/components/skeletons/MapSkeleton.tsx
@@ -3,7 +3,7 @@ import { Shimmer } from './Shimmer';
 
 export const MapSkeleton = React.memo(function MapSkeleton() {
   return (
-    <div className="relative flex min-h-[320px] w-full flex-col items-center justify-center overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
+    <div className="relative flex h-[320px] w-full flex-col items-center justify-center overflow-hidden rounded-[28px] border border-[#A7C957]/30 bg-[#0A1020] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.42)]">
       <Shimmer className="absolute inset-0 w-full h-full rounded-[28px]" />
       
       {/* Optional subtle pulsing placeholder icon to give visual context */}

--- a/src/components/skeletons/__tests__/MapSkeleton.test.tsx
+++ b/src/components/skeletons/__tests__/MapSkeleton.test.tsx
@@ -3,11 +3,14 @@ import { render } from '@testing-library/react';
 import { MapSkeleton } from '../MapSkeleton';
 
 describe('MapSkeleton Component', () => {
-  it('renders and matches the map container dimensions', () => {
+  it('reserves a hard-locked height matching the map container (prevents CLS)', () => {
     const { container } = render(<MapSkeleton />);
     const skeletonDiv = container.firstChild as HTMLElement;
     expect(skeletonDiv).toBeInTheDocument();
-    expect(skeletonDiv).toHaveClass('min-h-[320px]');
+    // Fixed height (not min-height) so the reserved box cannot grow or shift
+    // when the dynamic Leaflet map and its remote tiles mount in its place.
+    expect(skeletonDiv).toHaveClass('h-[320px]');
+    expect(skeletonDiv).not.toHaveClass('min-h-[320px]');
     expect(skeletonDiv).toHaveClass('w-full');
   });
 });


### PR DESCRIPTION
## Summary

Hard-locks the **Live Network Map** ("regional image map") block to exact, reserved dimensions so it can't shift layout (CLS) as the dynamic Leaflet map and its remote CARTO tiles mount.

Closes #397

## Problem

The map block reserved vertical space with `min-height`, which is a *floor*, not a lock. Across its lifecycle the reserved box could vary/grow:

- `MapSkeleton` (dynamic-import fallback) → `min-h-[320px]`
- `Map.tsx` loading / error / loaded outer → `min-h-[320px]`; inner media containers → `h-full min-h-[280px]`
- `MapContainer` (Leaflet) → fixed `280px`

When a `min-height` box is swapped for content that resolves asynchronously (the `next/dynamic` map + remote tile PNGs), the surrounding dashboard content can move — exactly the layout-stability regression described in the issue.

## Fix

Lock every layer of the block to an exact, hard-coded height so the bounds are fully reserved **before** any media resolves. Visually identical — the rendered sizes are unchanged (320px block / 280px map canvas):

| Element | Before | After |
|---|---|---|
| `MapSkeleton` outer | `min-h-[320px]` | `h-[320px]` |
| `Map` loading / error / loaded outer | `min-h-[320px]` | `h-[320px]` |
| `Map` inner media containers | `h-full min-h-[280px]` | `h-[280px]` |

`h-[320px]` outer with `p-5` (20px) padding reserves exactly `280px` for the inner container, which matches the Leaflet `MapContainer`'s existing fixed `height: 280px`. The skeleton, loading, error, and loaded states now share **identical fixed bounds**, so the dynamic-import swap and tile loads cannot move surrounding content.

## Tests

Updated `MapSkeleton.test.tsx` to assert the fixed height and the *absence* of `min-h-[320px]`, so the lock is regression-protected:

```tsx
expect(skeletonDiv).toHaveClass('h-[320px]');
expect(skeletonDiv).not.toHaveClass('min-h-[320px]');
```

Scope is limited to the map block (skeleton + `Map.tsx`) per the issue; no unrelated cells touched.

## ⚠️ Note for maintainers — pre-existing build break on `main` (unrelated to this PR)

`main` does not currently `next build` — there are pre-existing parse errors in files this PR does not touch, so the Vercel check will be red until they're fixed:

- **`src/app/components/PriceFeedCard.tsx:212-213`** — a duplicated `useCallback` closer; two consecutive dependency-array lines:
  ```ts
  }, [wsUpdate, enableWebSocket, isPageVisible, setError]); // ...
  }, [wsUpdate, enableWebSocket, isPageVisible, mounted, setError]); // ...
  ```
  One of these lines is a leftover and must be removed.
- **`src/app/hooks/useSocket.ts:260`** — `Expected ';', got ')'` (malformed block in the same area).

I confirmed these exist on `main` independently of this branch (`npx tsc --noEmit` reports the same 13 errors with my changes stashed) and deliberately did **not** fix them here, since they're unrelated to the CLS issue and out of scope. Happy to open a separate PR for the build fix if useful — this CLS change is a pure CSS-class lock (verified by inspection + the updated unit test).
