### PR TITLE
fix: add CSS layout/paint containment to telemetry stat cards

### DIFF
--- a/src/app/dashboard/corridors/page.tsx
+++ b/src/app/dashboard/corridors/page.tsx
@@ -61,7 +61,10 @@ export default function CorridorMonitorPage() {
 
           {/* Module 2: Synthetic Analytics / Flow Summary Component */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+            <div
+              style={{ contain: "layout paint" }}
+              className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+            >
               <span className="text-xs font-mono text-neutral-400 block mb-1">
                 AGGREGATED 24H FLOW
               </span>
@@ -69,7 +72,10 @@ export default function CorridorMonitorPage() {
                 $7,020,000
               </span>
             </div>
-            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+            <div
+              style={{ contain: "layout paint" }}
+              className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+            >
               <span className="text-xs font-mono text-neutral-400 block mb-1">
                 AVERAGE NETWORK SPREAD
               </span>
@@ -77,7 +83,10 @@ export default function CorridorMonitorPage() {
                 0.35%
               </span>
             </div>
-            <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+            <div
+              style={{ contain: "layout paint" }}
+              className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+            >
               <span className="text-xs font-mono text-neutral-400 block mb-1">
                 GLOBAL INGESTION HEALTH
               </span>

--- a/src/app/dashboard/validators/page.tsx
+++ b/src/app/dashboard/validators/page.tsx
@@ -71,22 +71,34 @@ export default function ValidatorAuditPage() {
 
       {/* Grid Overview Metrics */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+        <div
+          style={{ contain: "layout paint" }}
+          className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+        >
           <span className="text-xs font-mono text-neutral-400 block mb-1">TOTAL ACTIVE VALIDATORS</span>
           <span className="text-2xl font-bold font-mono text-neutral-100">
             {validators.filter((v) => v.status === "active").length} /{" "}
             {validators.length}
           </span>
         </div>
-        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+        <div
+          style={{ contain: "layout paint" }}
+          className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+        >
           <span className="text-xs font-mono text-neutral-400 block mb-1">TOTAL CAPITAL STAKED</span>
           <span className="text-2xl font-bold font-mono text-lime-400">107,000 XLM</span>
         </div>
-        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+        <div
+          style={{ contain: "layout paint" }}
+          className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+        >
           <span className="text-xs font-mono text-neutral-400 block mb-1">CUMULATIVE SLASH EVENTS</span>
           <span className="text-2xl font-bold font-mono text-red-400">9 Infracs</span>
         </div>
-        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+        <div
+          style={{ contain: "layout paint" }}
+          className="bg-neutral-900 border border-neutral-800 rounded-xl p-4"
+        >
           <span className="text-xs font-mono text-neutral-400 block mb-1">NETWORK HEARTBEAT INDEX</span>
           <span className="text-2xl font-bold font-mono text-emerald-400">93.15%</span>
         </div>


### PR DESCRIPTION
## Summary
- Minor text-value changes on the corridors and validators dashboard stat cards were not isolated with CSS containment, so layout engines could run reflow checks across the full document tree on every update.
- Add `contain: layout paint` inline to the stat cards in `src/app/dashboard/corridors/page.tsx` (Aggregated 24h Flow, Average Network Spread, Global Ingestion Health) and `src/app/dashboard/validators/page.tsx` (Total Active Validators, Total Capital Staked, Cumulative Slash Events, Network Heartbeat Index), matching the existing pattern already used by `ModularStatsCard`, `PriceFeedCard`, and other isolated stats widgets in the codebase.

Closes #360

## Test plan
- [x] `npm run lint` on the changed files — no new errors/warnings introduced
- [x] `npm test` — passes
- [x] Visually confirmed both dashboard pages still render the stat cards identically (no styling regression), containment is purely a paint/layout isolation hint