### PR TITLE
fix(build): repair 3 merge-corrupted files (refs #445)

### DIFF
--- a/src/app/components/OracleHealthIndicator.tsx
+++ b/src/app/components/OracleHealthIndicator.tsx
@@ -60,7 +60,16 @@ const OracleHealthIndicator = ({ status = "Online" }: OracleHealthIndicatorProps
         {/* Ping ring — only for Online */}
         {config.pulse && (
           <div
-
+            className={`absolute w-4 h-4 rounded-full ${config.dotColor} status-ping opacity-30`}
+          />
+        )}
+        {/* Core dot — animate-pulse only for Online */}
+        <div
+          className={[
+            "relative w-3 h-3 rounded-full",
+            config.dotColor,
+            config.dotGlow,
+            config.pulse ? "status-pulse" : "",
           ]
             .filter(Boolean)
             .join(" ")}

--- a/src/app/components/PriceFeedCard.tsx
+++ b/src/app/components/PriceFeedCard.tsx
@@ -17,7 +17,7 @@ import { useErrorTimeout } from "../hooks/useErrorTimeout";
 import { useSocketConnection, useSocketData } from "./providers/SocketProvider";
 import { Shimmer } from "@/components/skeletons/Shimmer";
 import { getCachedHistory, getCachedHistorySync, setCachedHistory } from "../lib/historySync";
-import { PriceFeedCardSkeleton, Shimmer } from "@/components/skeletons";
+import { PriceFeedCardSkeleton } from "@/components/skeletons/PriceFeedCardSkeleton";
 import { useMounted } from "@/app/hooks/useMounted";
 import { POLLING_INTERVALS, INACTIVITY_CONFIG } from "@/config/cacheConfig";
 
@@ -117,11 +117,10 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
   refreshInterval = POLLING_INTERVALS.MEDIUM_INTERVAL,
   enableWebSocket = true,
 }) => {
+  const mounted = useMounted();
   const [data, setData] = useState<PriceFeedData | null>(() => {
     return getCachedHistorySync<PriceFeedData>("price-feed:ngn-xlm");
   });
-  const mounted = useMounted();
-  const [data, setData] = useState<PriceFeedData | null>(null);
   const [loading, setLoading] = useState(true);
   const { error, setError } = useErrorTimeout({ timeoutMs: 5000 });
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
@@ -209,7 +208,6 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
     setLastRefresh(new Date());
     setLoading(false);
     setError(null);
-  }, [wsUpdate, enableWebSocket, isPageVisible, setError]); // `data` intentionally omitted — accessed via functional updater
   }, [wsUpdate, enableWebSocket, isPageVisible, mounted, setError]); // `data` intentionally omitted — accessed via functional updater
 
   // Handle WebSocket errors
@@ -219,20 +217,11 @@ const PriceFeedCard: React.FC<PriceFeedCardProps> = ({
     if (wsError && enableWebSocket) {
       setError(`WebSocket error: ${wsError}`);
     }
-  }, [wsError, enableWebSocket, setError]);
   }, [wsError, enableWebSocket, mounted, setError]);
 
   // Initial fetch + fallback polling (only when WebSocket is disabled or disconnected)
   const pollingActive = mounted && isPageVisible && (!enableWebSocket || !isConnected);
   useEffect(() => {
-    if (!pollingActive) return;
-
-    const timer = window.setTimeout(() => {
-      void load();
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [pollingActive, load]);
     if (!mounted) return;
     if (!pollingActive) return;
 

--- a/src/app/hooks/useValidatorBatch.ts
+++ b/src/app/hooks/useValidatorBatch.ts
@@ -31,6 +31,10 @@ export function useValidatorBatch(
   const historyKey = `validators:${normalizedAddresses.join(',')}`;
   const initialData = getCachedHistorySync<ValidatorMetric[]>(historyKey) ?? undefined;
 
+  // Use SHORT_INTERVAL (10s) to prevent excessive validator metric lookups
+  // while keeping data reasonably fresh for status monitoring.
+  const cacheConfig = getCacheOptions('SHORT_INTERVAL');
+
   return useQuery<ValidatorMetric[], Error>({
     queryKey,
     queryFn: async () => {
@@ -42,15 +46,6 @@ export function useValidatorBatch(
       }
 
       const url = `/api/validators?ids=${normalizedAddresses.map(encodeURIComponent).join(',')}`;
-  // Use SHORT_INTERVAL (10s) to prevent excessive validator metric lookups
-  // while keeping data reasonably fresh for status monitoring.
-  const cacheConfig = getCacheOptions('SHORT_INTERVAL');
-
-  return useQuery<ValidatorMetric[], Error>({
-    queryKey,
-    queryFn: async () => {
-      if (addresses.length === 0) return [];
-      const url = `/api/validators?ids=${addresses.map(encodeURIComponent).join(',')}`;
       const res = await fetch(url, {
         method: 'GET',
         cache: 'no-store',
@@ -68,10 +63,8 @@ export function useValidatorBatch(
     refetchOnWindowFocus: false,
     // Keep previous data while loading new batched results.
     keepPreviousData: true,
-    // Stale time can be tuned; using 30 seconds as a sensible default.
-    staleTime: 30_000,
-    refetchOnWindowFocus: false,
     placeholderData: (previousData) => previousData,
+    // Cache intervals come from the centralized cache config (SHORT_INTERVAL = 10s).
     staleTime: cacheConfig.staleTime,
     gcTime: cacheConfig.gcTime,
   });


### PR DESCRIPTION
## Summary

`main` does not build. Several `Merge branch 'main' into <feature>` commits were resolved by keeping **both** sides of the conflict, landing parse errors on `main` (no CI build gate to catch them). Full diagnosis in #445.

This PR repairs **3 of the 4** affected files. `useSocket.ts` is intentionally left out — it needs a maintainer decision (see #445 and the note below).

Refs #445

## Changes

- **`OracleHealthIndicator.tsx`** — restore the status-dot block (ping-ring `className` + the core-dot's opening `<div>` and `className={[...]}` array) that merge `77f2658` deleted, leaving an orphan `]`. The same merge's legitimate `style={{ contain: "layout paint" }}` change is preserved.
- **`useValidatorBatch.ts`** — merge `736792a` nested two `useQuery` calls and left duplicate keys (`refetchOnWindowFocus`, `staleTime`). Collapsed to one, reconciling both branches: `normalizedAddresses` + in-fn cache check **and** `getCacheOptions('SHORT_INTERVAL')`-driven `staleTime`/`gcTime`.
- **`PriceFeedCard.tsx`** — merge `be3793b` kept both sides at several sites:
  - deduped the `Shimmer` import and switched to the individual skeleton paths (the `@/components/skeletons` barrel was removed in the "eliminate barrel files" commit, so that import didn't resolve);
  - removed the duplicate `const [data, setData] = useState(...)` (kept the cache-seeded initializer);
  - kept the `mounted`-guarded dependency arrays on the WS-merge and WS-error effects;
  - collapsed the duplicated polling `useEffect`.

## Verification

```
npx tsc --noEmit
```
After this PR, the **only** remaining error is the pre-existing `useSocket.ts` parse error — every other file now type-checks. Each change was recovered from git history / reconciled to the evident intent of the conflicting branches; no behavior was invented.

## ⚠️ Not included: `useSocket.ts` (needs a maintainer decision)

`useSocket.ts` was corrupted by merge `b9e517f`, which interleaved **two incompatible implementations** — an older `wsManager` connection-pool version and a newer direct-`new WebSocket()` rewrite. The result is semantically broken (e.g. `disconnect` is defined twice, and one body *subscribes* instead of disconnecting), and there's no clean version to recover from. Repairing it safely means **choosing one implementation** and rebuilding the hook — a call for the maintainers, since it's the live data-feed core. Details in #445.

So this PR gets the tree down to a single remaining broken file; once the `useSocket.ts` direction is decided, the build goes green. Happy to follow up on `useSocket.ts` once you confirm which implementation to keep.
