### PR TITLE
[codex] Scope config providers to consumers

### DIFF
--- a/src/app/DashboardInteractive.tsx
+++ b/src/app/DashboardInteractive.tsx
@@ -11,6 +11,8 @@ import { DashboardTrafficChartSkeleton } from "@/components/skeletons/DashboardT
 import { useMounted } from "@/app/hooks/useMounted";
 import WebSocketTest from "./components/test/WebSocketTest";
 import { CorridorProvider } from "@/context/CorridorContext";
+import { SocketProvider } from "./components/providers/SocketProvider";
+import { ASSET_SYMBOLS } from "@/config/assetSymbols";
 
 const LiveNetworkMap = dynamic(() => import("@/app/components/Map"), {
   ssr: false,
@@ -284,7 +286,10 @@ export default function DashboardInteractive({
         will re-render on price ticks. All other layout panels above and below
         this boundary are shielded by React.memo rendering gates.
       */}
-      <CorridorProvider>
+      <SocketProvider
+        options={{ assetIds: [ASSET_SYMBOLS.NGN_XLM], enableDeltaUpdates: true }}
+      >
+        <CorridorProvider>
         {/* Dynamic Price Feed — NGN/XLM */}
         <section className="min-w-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <div className="min-w-0 w-full max-w-full aspect-auto sm:aspect-4/3 min-h-[260px] sm:min-h-[320px] overflow-hidden">
@@ -296,7 +301,8 @@ export default function DashboardInteractive({
         <section className="flex justify-center">
           <WebSocketTest />
         </section>
-      </CorridorProvider>
+        </CorridorProvider>
+      </SocketProvider>
 
       {/* Live Network Map — memo-gated, no socket dependency */}
       <NetworkMapSection />

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -7,9 +7,9 @@ import { useRouter, usePathname } from "next/navigation";
 import Icon from "@/components/icons/Icon";
 import { ICON_IDS } from "@/components/icons/iconIds";
 import { useProgressBar } from "./TopLoadingBar";
-import { useWallet, useWalletStatus, useWalletActions } from "../hooks/useWalletState";
+import { WalletProvider, useWallet, useWalletStatus, useWalletActions } from "../hooks/useWalletState";
 
-const WalletConnectButton = memo(() => {
+const WalletConnectButtonContent = memo(() => {
   const { wallet } = useWallet();
   const { isChecking } = useWalletStatus();
   const { refreshWalletState } = useWalletActions();
@@ -44,6 +44,13 @@ const WalletConnectButton = memo(() => {
     </button>
   );
 });
+WalletConnectButtonContent.displayName = "WalletConnectButtonContent";
+
+const WalletConnectButton = memo(() => (
+  <WalletProvider>
+    <WalletConnectButtonContent />
+  </WalletProvider>
+));
 WalletConnectButton.displayName = "WalletConnectButton";
 
 const Nav = memo(() => {

--- a/src/app/components/test/WebSocketTest.tsx
+++ b/src/app/components/test/WebSocketTest.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import React from "react";
-import { useSocket } from "../../hooks/useSocket";
 import { useMounted } from "@/app/hooks/useMounted";
 import { Shimmer } from "@/components/skeletons/Shimmer";
 import { ASSET_SYMBOLS } from "@/config/assetSymbols";
+import {
+  useCorridorActions,
+  useCorridorConnection,
+  useCorridorStream,
+} from "@/context/CorridorContext";
 
 function WebSocketTestSkeleton() {
   return (
@@ -29,17 +33,9 @@ function WebSocketTestSkeleton() {
 
 export default function WebSocketTest() {
   const mounted = useMounted();
-  const {
-    isConnected,
-    lastUpdate,
-    error,
-    reconnectAttempts,
-    subscribeToAsset,
-    unsubscribeFromAsset,
-  } = useSocket({
-    assetIds: [ASSET_SYMBOLS.NGN_XLM],
-    enableDeltaUpdates: true,
-  });
+  const { isConnected, error, reconnectAttempts } = useCorridorConnection();
+  const { lastUpdate } = useCorridorStream();
+  const { subscribeToAsset, unsubscribeFromAsset } = useCorridorActions();
 
   if (!mounted) {
     return <WebSocketTestSkeleton />;

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -17,7 +17,7 @@ import { subscribe } from '@/workers/masterTimerWorker';
 import { withShortenedAddressField } from '@/utils/addressUtils';
 import { useIsHydrated } from '@/app/hooks/useIsHydrated';
 
-import { useWallet, useWalletStatus, useWalletActions } from '@/app/hooks/useWalletState';
+import { WalletProvider, useWallet, useWalletStatus, useWalletActions } from '@/app/hooks/useWalletState';
 import Icon from '@/components/icons/Icon';
 import { ICON_IDS } from '@/components/icons/iconIds';
 
@@ -41,7 +41,7 @@ const MOCK_PROPOSALS: Proposal[] = [
   { id: 'SFP-09', title: 'Increase Relayer Missed-Heartbeat Penalty Weight by 2%', proposer: 'GCXXVHZLKMNPQRSXYZABCDEFGHIJKLM7766', status: 'Defeated', votesFor: 110000, votesAgainst: 920000, quorumThreshold: 50, endsInLedgers: 0 },
 ];
 
-const GovernanceWalletControl = React.memo(function GovernanceWalletControl() {
+const GovernanceWalletControlContent = React.memo(function GovernanceWalletControlContent() {
   const { wallet } = useWallet();
   const { isChecking } = useWalletStatus();
   const { refreshWalletState } = useWalletActions();
@@ -81,6 +81,14 @@ const GovernanceWalletControl = React.memo(function GovernanceWalletControl() {
     </div>
   );
 });
+
+function GovernanceWalletControl() {
+  return (
+    <WalletProvider>
+      <GovernanceWalletControlContent />
+    </WalletProvider>
+  );
+}
 
 export default function GovernancePage() {
   const [activeTab, setActiveTab] = useState<'all' | 'active' | 'archived'>('all');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,6 @@ import "./globals.css";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { ProgressBarProvider } from "./components/TopLoadingBar";
 import { UserProvider } from "./components/providers/UserProvider";
-import { SocketProvider } from "./components/providers/SocketProvider";
-import { WalletProvider } from "./components/providers/WalletProvider";
 import { QueryProvider } from "./components/providers/QueryProvider";
 import Script from "next/script";
 import SvgSprite from "@/components/icons/SvgSprite";
@@ -84,17 +82,11 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <UserProvider>
-            {/* SocketProvider wraps the full app so any route can consume
-                live WebSocket data without re-mounting on navigation. */}
-            <SocketProvider>
-              <WalletProvider>
-                <QueryProvider>
-                  <ProgressBarProvider>
-                    {children}
-                  </ProgressBarProvider>
-                </QueryProvider>
-              </WalletProvider>
-            </SocketProvider>
+            <QueryProvider>
+              <ProgressBarProvider>
+                {children}
+              </ProgressBarProvider>
+            </QueryProvider>
           </UserProvider>
         </ThemeProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import SystemStats from "./components/SystemStats";
 import ModularStatsCard from "./components/ModularStatsCard";
 import RelayerStatusTable from "./components/RelayerStatusTable";
 import DashboardInteractive from "./DashboardInteractive";
-import { SocketProvider } from "./components/providers/SocketProvider";
 
 const mockRelayers = [
   { id: "r1", name: "Abuja Relayer", status: "Online" as const, latency: 34 },
@@ -77,9 +76,7 @@ export default function Page() {
           </section>
 
           {/* Client-rendered interactive sections */}
-          <SocketProvider>
-            <DashboardInteractive rateCards={rateCards} />
-          </SocketProvider>
+          <DashboardInteractive rateCards={rateCards} />
 
           {/* Relayer Status Table — server-rendered static HTML */}
           <section

--- a/src/context/CorridorContext.tsx
+++ b/src/context/CorridorContext.tsx
@@ -3,8 +3,8 @@
 /**
  * CorridorContext — focused sub-context node for live socket stream state.
  *
- * Problem: funnelling WebSocket price-tick state through the monolithic root
- * SocketProvider triggers full component-tree re-renders on every tick,
+ * Problem: funnelling WebSocket price-tick state through a broad root
+ * SocketProvider can trigger full component-tree re-renders on every tick,
  * including stable navigation and layout panels that have no dependency on
  * live price data.
  *
@@ -37,6 +37,7 @@ interface CorridorStreamContextType {
 interface CorridorConnectionContextType {
   isConnected: boolean;
   error: string | null;
+  reconnectAttempts: number;
 }
 
 /** Stable corridor action callbacks — identity never changes after mount. */
@@ -73,10 +74,10 @@ interface CorridorProviderProps {
  * must remain outside so they are never re-rendered by socket ticks.
  */
 export function CorridorProvider({ children }: CorridorProviderProps) {
-  // Pull the three independent slices from the root SocketProvider.
+  // Pull the three independent slices from the local SocketProvider.
   // Each hook already subscribes to only its own slice, so only the relevant
   // re-render cascade is triggered inside this sub-tree.
-  const { isConnected, error } = useSocketConnection();
+  const { isConnected, error, reconnectAttempts } = useSocketConnection();
   const { lastUpdate } = useSocketData();
   const { subscribeToAsset, unsubscribeFromAsset, reconnect } = useSocketActions();
 
@@ -89,8 +90,8 @@ export function CorridorProvider({ children }: CorridorProviderProps) {
   );
 
   const connectionValue = useMemo<CorridorConnectionContextType>(
-    () => ({ isConnected, error }),
-    [isConnected, error],
+    () => ({ isConnected, error, reconnectAttempts }),
+    [isConnected, error, reconnectAttempts],
   );
 
   const actionsValue = useMemo<CorridorActionsContextType>(


### PR DESCRIPTION
Close #462 
## What changed
- Removed wallet and socket providers from the app-wide root layout.
- Kept theme, user, query, and progress providers global because they support the broad app shell.
- Wrapped wallet state only around the nav wallet button and governance wallet control.
- Scoped socket state to the dashboard live price/test section and had the WebSocket test panel consume the same corridor context as the price card.

## Why
This narrows high-frequency price-feed updates and wallet refresh state to the components that actually consume them, reducing unrelated component re-renders from global provider changes.

## Validation
- git diff --check
- npm run lint could not run because local dependencies were missing.
- npm ci was attempted twice, but registry fetches failed/timed out with ECONNRESET before eslint/next/tsc binaries were installed.