### PR TITLE
fix: unsubscribe invariant interceptor tasks on cleanup to prevent memory leaks

### DIFF
--- a/src/app/hooks/useSocket.ts
+++ b/src/app/hooks/useSocket.ts
@@ -145,7 +145,7 @@ function useSocketState(options: UseSocketOptions): UseSocketReturn {
 
     wsManager.subscribeToMessages(handleIncomingData);
     wsManager.subscribeToStatus(handleStatusChange);
-    wsManager.connect();
+    wsManager.addConsumer();
 
     const assetsOnMount = Array.from(subscribedAssetsRef.current);
     if (assetsOnMount.length > 0) {
@@ -155,10 +155,16 @@ function useSocketState(options: UseSocketOptions): UseSocketReturn {
     return () => {
       wsManager.unsubscribeFromMessages(handleIncomingData);
       wsManager.unsubscribeFromStatus(handleStatusChange);
-      if (assetsOnMount.length > 0) {
-        wsManager.unsubscribeFromAssets(assetsOnMount);
+      // Unsubscribe from ALL assets this consumer is tracking — not just the
+      // snapshot captured at mount — so dynamically added subscriptions are
+      // cleaned up and do not leak in the singleton manager.
+      const remaining = Array.from(subscribedAssetsRef.current);
+      if (remaining.length > 0) {
+        wsManager.unsubscribeFromAssets(remaining);
+        subscribedAssetsRef.current.clear();
       }
       flushPendingUpdates();
+      wsManager.removeConsumer();
     };
   }, [wsManager, isVisible, setError, flushPendingUpdates]);
 

--- a/src/utils/WebSocketManager.ts
+++ b/src/utils/WebSocketManager.ts
@@ -24,6 +24,11 @@ export class WebSocketManager {
   private globalSubscribedAssets: Set<string> = new Set();
   private isConnected: boolean = false;
 
+  // Reference count of active consumers. When this drops to 0 the underlying
+  // WebSocket is torn down so background work stops. It is re-established on
+  // the next `addConsumer()` call.
+  private consumerCount: number = 0;
+
   private constructor() {}
 
   public static getInstance(): WebSocketManager {
@@ -32,6 +37,26 @@ export class WebSocketManager {
     }
     return WebSocketManager.instance;
   }
+
+  // ---- consumer lifecycle --------------------------------------------------
+
+  /** Register an active consumer. Connects the socket if this is the first. */
+  public addConsumer(): void {
+    this.consumerCount++;
+    if (this.consumerCount === 1) {
+      this.connect();
+    }
+  }
+
+  /** Deregister a consumer. Tears down the socket when no consumers remain. */
+  public removeConsumer(): void {
+    this.consumerCount = Math.max(0, this.consumerCount - 1);
+    if (this.consumerCount === 0) {
+      this.disconnect();
+    }
+  }
+
+  // ---- connection management -----------------------------------------------
 
   public connect() {
     if (typeof window === "undefined") return;
@@ -71,6 +96,21 @@ export class WebSocketManager {
     } catch (err) {
       console.error("Failed to establish centralized WebSocket connection", err);
     }
+  }
+
+  /** Close the WebSocket and clear all server-side subscriptions. */
+  private disconnect() {
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onmessage = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.close();
+      this.ws = null;
+    }
+    this.isConnected = false;
+    this.globalSubscribedAssets.clear();
+    this.notifyStatusListeners(false);
   }
 
   // Subscribe a component listener to message data events


### PR DESCRIPTION
# Memory-Leak | Unsubscribing Invariant Interceptor Tasks on Cleanups #386
Closes #386 
## Problem

The `WebSocketManager` singleton never closed its WebSocket connection when all consuming components unmounted. This meant the underlying socket, its event handlers, and server-side subscriptions persisted as background resource leaks when users navigated between workspace environments.

Additionally, `useSocket` cleanup only unsubscribed assets captured at mount time (`assetsOnMount`), missing any assets dynamically subscribed during the component's lifecycle via `subscribeToAsset()`.

## Changes

### `src/utils/WebSocketManager.ts`
- Added `consumerCount` reference counter to track active `useSocket` consumers.
- Added `addConsumer()` — increments the counter and connects the socket on the first consumer.
- Added `removeConsumer()` — decrements the counter and calls `disconnect()` when it reaches zero.
- Added private `disconnect()` — nulls all WebSocket handlers, closes the socket, clears `globalSubscribedAssets`, and notifies status listeners of disconnection.

### `src/app/hooks/useSocket.ts`
- Mount effect now calls `wsManager.addConsumer()` instead of `wsManager.connect()` directly, delegating connection lifecycle to the manager's reference counting.
- Cleanup now reads `subscribedAssetsRef.current` (the full set of assets tracked at unmount time) instead of the mount-time snapshot, so dynamically added subscriptions are properly cleaned up.
- Cleanup calls `wsManager.removeConsumer()` after unsubscribing, allowing the singleton to tear down the WebSocket when no consumers remain.

## Impact

- The WebSocket connection is fully closed when all consumers navigate away, eliminating persistent background resource leaks.
- All dynamically subscribed assets are unsubscribed on cleanup, preventing stale subscriptions in the singleton manager.
- No changes to public API or component behavior; the fix is transparent to consumers.
