### PR TITLE
feat: configurable slippage tolerance modal for swaps

### DIFF
--- a/src/app/hooks/useSlippageTolerance.ts
+++ b/src/app/hooks/useSlippageTolerance.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+import { loadStoredSlippage, saveStoredSlippage } from "@/lib/slippage";
+
+/**
+ * Persists the user's chosen slippage tolerance (percentage) to localStorage
+ * so it survives across swap sessions. This hook only mounts inside
+ * `SlippageModal`, which is conditionally rendered client-side (never part
+ * of server-rendered HTML), so reading localStorage in the lazy state
+ * initializer is safe from hydration mismatches.
+ */
+export function useSlippageTolerance() {
+  const [slippagePercent, setSlippagePercentState] = useState<number>(
+    () => loadStoredSlippage(),
+  );
+
+  const setSlippagePercent = useCallback((percent: number) => {
+    setSlippagePercentState(percent);
+    saveStoredSlippage(percent);
+  }, []);
+
+  return { slippagePercent, setSlippagePercent };
+}
+
+export default useSlippageTolerance;

--- a/src/components/swap/SlippageModal.tsx
+++ b/src/components/swap/SlippageModal.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import OptimizedDialog from "@/app/components/OptimizedDialog";
+import { useSlippageTolerance } from "@/app/hooks/useSlippageTolerance";
+import Icon from "@/components/icons/Icon";
+import { ICON_IDS } from "@/components/icons/iconIds";
+import {
+  PRESET_SLIPPAGE_OPTIONS,
+  calculateMinAmountOut,
+  validateSlippagePercent,
+} from "@/lib/slippage";
+
+export interface SlippageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Quoted output amount for the pending swap, used to preview the
+   * `min_amount_out` value that will be sent to the Soroban transaction
+   * builder for the selected tolerance.
+   */
+  quotedAmountOut?: number;
+  outputAssetSymbol?: string;
+  /** Called with the confirmed slippage percentage and its derived min_amount_out. */
+  onConfirm?: (slippagePercent: number, minAmountOut: number | null) => void;
+}
+
+export function SlippageModal({
+  isOpen,
+  onClose,
+  quotedAmountOut,
+  outputAssetSymbol = "",
+  onConfirm,
+}: SlippageModalProps) {
+  const { slippagePercent, setSlippagePercent } = useSlippageTolerance();
+  const [customInput, setCustomInput] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const isPresetActive = (preset: number) =>
+    customInput === "" && slippagePercent === preset;
+
+  const activeValue = customInput !== "" ? Number(customInput) : slippagePercent;
+  const validation = useMemo(
+    () => validateSlippagePercent(activeValue),
+    [activeValue],
+  );
+
+  const minAmountOut = useMemo(() => {
+    if (!validation.valid || quotedAmountOut === undefined) {
+      return null;
+    }
+    return calculateMinAmountOut(quotedAmountOut, activeValue);
+  }, [validation.valid, quotedAmountOut, activeValue]);
+
+  const selectPreset = (preset: number) => {
+    setCustomInput("");
+    setSlippagePercent(preset);
+  };
+
+  const handleCustomChange = (value: string) => {
+    setTouched(true);
+    setCustomInput(value);
+    const parsed = Number(value);
+    if (value !== "" && validateSlippagePercent(parsed).valid) {
+      setSlippagePercent(parsed);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!validation.valid) return;
+    onConfirm?.(activeValue, minAmountOut);
+    onClose();
+  };
+
+  return (
+    <OptimizedDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Slippage Tolerance"
+      size="sm"
+    >
+      <div className="space-y-5">
+        <div>
+          <p className="text-xs uppercase font-bold text-gray-500 mb-2">
+            Preset Tolerance
+          </p>
+          <div className="grid grid-cols-3 gap-2">
+            {PRESET_SLIPPAGE_OPTIONS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => selectPreset(preset)}
+                className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                  isPresetActive(preset)
+                    ? "border-blue-500 bg-blue-500/10 text-blue-300"
+                    : "border-gray-700 text-gray-300 hover:bg-gray-800"
+                }`}
+              >
+                {preset}%
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="custom-slippage"
+            className="text-xs uppercase font-bold text-gray-500"
+          >
+            Custom
+          </label>
+          <div className="relative">
+            <input
+              id="custom-slippage"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step={0.1}
+              value={customInput}
+              onChange={(event) => handleCustomChange(event.target.value)}
+              onBlur={() => setTouched(true)}
+              placeholder={slippagePercent.toString()}
+              className="w-full rounded-lg border border-gray-700 bg-[#0d1117] px-3 py-2.5 pr-8 text-sm text-gray-200 placeholder:text-gray-600 focus:border-blue-500 focus:outline-none"
+              aria-invalid={touched && !validation.valid}
+              aria-describedby="custom-slippage-warning custom-slippage-error"
+            />
+            <Icon
+              id={ICON_IDS.percent}
+              size={14}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
+            />
+          </div>
+          {touched && validation.error && (
+            <p
+              id="custom-slippage-error"
+              className="text-xs text-red-400"
+              role="alert"
+            >
+              {validation.error}
+            </p>
+          )}
+        </div>
+
+        {validation.valid && validation.isHighRisk && (
+          <div
+            id="custom-slippage-warning"
+            className="flex items-start gap-2 rounded-lg border border-yellow-500/40 bg-yellow-950/20 px-3 py-2.5"
+            role="alert"
+          >
+            <Icon
+              id={ICON_IDS.alertTriangle}
+              size={16}
+              className="mt-0.5 shrink-0 text-yellow-400"
+            />
+            <p className="text-xs text-yellow-300">
+              High slippage tolerance. Your transaction may be frontrun or
+              executed at an unfavorable rate.
+            </p>
+          </div>
+        )}
+
+        {quotedAmountOut !== undefined && (
+          <div className="rounded-lg border border-gray-800 bg-[#0d1117] p-3">
+            <p className="text-xs uppercase font-bold text-gray-500">
+              Minimum Received
+            </p>
+            <p className="mt-1 font-mono text-lg text-gray-100">
+              {minAmountOut !== null ? minAmountOut : "—"}{" "}
+              <span className="text-sm font-normal text-gray-400">
+                {outputAssetSymbol}
+              </span>
+            </p>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!validation.valid}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </OptimizedDialog>
+  );
+}
+
+export default SlippageModal;

--- a/src/lib/slippage.ts
+++ b/src/lib/slippage.ts
@@ -1,0 +1,117 @@
+/**
+ * Slippage tolerance helpers for swap transactions.
+ *
+ * Slippage is expressed as a percentage (e.g. `0.5` for 0.5%) and used to
+ * derive the `min_amount_out` guard passed to the Soroban swap transaction
+ * builder, protecting the trader from excessive price movement between
+ * quote time and on-chain execution.
+ */
+
+export const PRESET_SLIPPAGE_OPTIONS = [0.1, 0.5, 1.0] as const;
+
+export type PresetSlippage = (typeof PRESET_SLIPPAGE_OPTIONS)[number];
+
+/** Custom slippage above this threshold is flagged as high risk in the UI. */
+export const HIGH_SLIPPAGE_WARNING_THRESHOLD = 5;
+
+/** Hard ceiling — values above this are rejected outright as invalid input. */
+export const MAX_SLIPPAGE_PERCENT = 50;
+
+const STORAGE_KEY = "stellarflow:slippage-tolerance";
+const DEFAULT_SLIPPAGE_PERCENT: PresetSlippage = 0.5;
+
+export interface SlippageValidationResult {
+  valid: boolean;
+  isHighRisk: boolean;
+  error: string | null;
+}
+
+/**
+ * Validates a user-supplied slippage percentage. Values must be a positive
+ * number no greater than `MAX_SLIPPAGE_PERCENT`; anything past
+ * `HIGH_SLIPPAGE_WARNING_THRESHOLD` is still valid but flagged as high risk.
+ */
+export function validateSlippagePercent(value: number): SlippageValidationResult {
+  if (!Number.isFinite(value) || value <= 0) {
+    return {
+      valid: false,
+      isHighRisk: false,
+      error: "Slippage must be a positive number.",
+    };
+  }
+
+  if (value > MAX_SLIPPAGE_PERCENT) {
+    return {
+      valid: false,
+      isHighRisk: false,
+      error: `Slippage cannot exceed ${MAX_SLIPPAGE_PERCENT}%.`,
+    };
+  }
+
+  return {
+    valid: true,
+    isHighRisk: value > HIGH_SLIPPAGE_WARNING_THRESHOLD,
+    error: null,
+  };
+}
+
+/**
+ * Computes the minimum acceptable output amount for a swap given the quoted
+ * output and a slippage tolerance percentage. Rounds down (floor) so the
+ * on-chain guard never permits less than the caller intended.
+ *
+ * @param quotedAmountOut expected output amount from the current quote
+ * @param slippagePercent tolerance, e.g. `0.5` for 0.5%
+ * @param decimals number of decimal places to preserve (default 7, Stellar's stroop precision)
+ */
+export function calculateMinAmountOut(
+  quotedAmountOut: number,
+  slippagePercent: number,
+  decimals = 7,
+): number {
+  if (!Number.isFinite(quotedAmountOut) || quotedAmountOut < 0) {
+    throw new RangeError("quotedAmountOut must be a non-negative number.");
+  }
+
+  const { valid, error } = validateSlippagePercent(slippagePercent);
+  if (!valid) {
+    throw new RangeError(error ?? "Invalid slippage percent.");
+  }
+
+  const factor = 1 - slippagePercent / 100;
+  const scale = 10 ** decimals;
+  return Math.floor(quotedAmountOut * factor * scale) / scale;
+}
+
+export function loadStoredSlippage(): number {
+  if (typeof window === "undefined") {
+    return DEFAULT_SLIPPAGE_PERCENT;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) {
+      return DEFAULT_SLIPPAGE_PERCENT;
+    }
+
+    const parsed = Number(raw);
+    return validateSlippagePercent(parsed).valid ? parsed : DEFAULT_SLIPPAGE_PERCENT;
+  } catch {
+    return DEFAULT_SLIPPAGE_PERCENT;
+  }
+}
+
+export function saveStoredSlippage(percent: number): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(percent));
+  } catch {
+    // localStorage may be unavailable (private browsing quota, etc.) — the
+    // in-memory value from this session still applies, so this is safe to ignore.
+  }
+}
+
+export { DEFAULT_SLIPPAGE_PERCENT };

--- a/src/lib/swapOps.ts
+++ b/src/lib/swapOps.ts
@@ -1,0 +1,140 @@
+/**
+ * Soroban swap contract operations.
+ *
+ * Stellar SDK and Freighter are lazy-loaded so they stay out of the initial bundle
+ * until a user explicitly submits a swap transaction.
+ */
+
+const SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+const DEFAULT_FEE = '100000';
+
+export interface SwapParams {
+  /** Soroban AMM/router contract address */
+  contractId: string;
+  /** Contract address of the asset being sold */
+  tokenInId: string;
+  /** Contract address of the asset being bought */
+  tokenOutId: string;
+  /** Amount of `tokenIn` to sell, in the token's smallest unit (stroops) */
+  amountIn: bigint;
+  /**
+   * Minimum acceptable amount of `tokenOut` to receive, in the token's
+   * smallest unit. Derived from the quoted output and the user's slippage
+   * tolerance via `calculateMinAmountOut` — the contract call reverts if the
+   * realized output would fall below this guard.
+   */
+  minAmountOut: bigint;
+}
+
+export interface SwapResult {
+  txHash: string;
+}
+
+async function waitForTransaction(
+  server: InstanceType<
+    Awaited<typeof import('@stellar/stellar-sdk')>['SorobanRpc']['Server']
+  >,
+  hash: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const response = await server.getTransaction(hash);
+
+    if (response.status === 'SUCCESS') {
+      return;
+    }
+
+    if (response.status === 'FAILED') {
+      throw new Error('Swap transaction failed on the Soroban network.');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error('Timed out waiting for swap transaction confirmation.');
+}
+
+/**
+ * Builds, signs (via Freighter), and submits a `swap()` Soroban invocation
+ * with the `min_amount_out` guard populated from the caller's slippage
+ * tolerance selection.
+ */
+export async function submitSwap({
+  contractId,
+  tokenInId,
+  tokenOutId,
+  amountIn,
+  minAmountOut,
+}: SwapParams): Promise<SwapResult> {
+  const { isConnected, getAddress, signTransaction } = await import(
+    '@stellar/freighter-api'
+  );
+  const {
+    Address,
+    Contract,
+    Networks,
+    SorobanRpc,
+    TransactionBuilder,
+    nativeToScVal,
+    Transaction,
+  } = await import('@stellar/stellar-sdk');
+
+  if (!(await isConnected())) {
+    throw new Error('Freighter wallet is not connected. Please connect your wallet first.');
+  }
+
+  const { address: publicKey } = await getAddress();
+  if (!publicKey) {
+    throw new Error('Could not retrieve public key from Freighter.');
+  }
+
+  const rpcServer = new SorobanRpc.Server(SOROBAN_RPC_URL, { allowHttp: true });
+  const contract = new Contract(contractId);
+
+  const sourceAccount = await rpcServer.getAccount(publicKey);
+
+  const builtTx = new TransactionBuilder(sourceAccount, {
+    fee: DEFAULT_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'swap',
+        Address.fromString(publicKey).toScVal(),
+        Address.fromString(tokenInId).toScVal(),
+        Address.fromString(tokenOutId).toScVal(),
+        nativeToScVal(amountIn, { type: 'i128' }),
+        nativeToScVal(minAmountOut, { type: 'i128' }),
+      ),
+    )
+    .setTimeout(180)
+    .build();
+
+  const preparedTx = await rpcServer.prepareTransaction(builtTx);
+
+  const { signedTxXdr, error } = await signTransaction(preparedTx.toXDR(), {
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  if (error || !signedTxXdr) {
+    throw new Error('Transaction signing failed or was canceled.');
+  }
+
+  const signedTx = TransactionBuilder.fromXDR(
+    signedTxXdr,
+    Networks.TESTNET,
+  ) as InstanceType<typeof Transaction>;
+
+  const submitResponse = await rpcServer.sendTransaction(signedTx);
+
+  if (submitResponse.status === 'ERROR') {
+    throw new Error(
+      submitResponse.errorResult
+        ? `Swap submission failed: ${submitResponse.errorResult}`
+        : 'Swap submission failed.',
+    );
+  }
+
+  await waitForTransaction(rpcServer, submitResponse.hash);
+
+  return { txHash: submitResponse.hash };
+}


### PR DESCRIPTION
## Summary
- Adds `SlippageModal` with preset (0.1% / 0.5% / 1.0%) and custom slippage tolerance controls
- Persists the chosen tolerance to localStorage across sessions
- Warns in the UI when custom slippage exceeds 5% (high risk)
- Adds `calculateMinAmountOut` to derive the `min_amount_out` guard from a quote + tolerance
- Adds `submitSwap` in `src/lib/swapOps.ts`, a Soroban `swap()` transaction builder (Freighter + stellar-sdk, lazy-loaded) that accepts `minAmountOut`

## Test plan
- [x] `tsc --noEmit` clean on all new files
- [x] `eslint` clean on all new files


Closes #526