### PR TITLE
feat: dynamic App Router pages for pools and corridors

### DIFF
--- a/src/app/corridors/[id]/loading.tsx
+++ b/src/app/corridors/[id]/loading.tsx
@@ -1,0 +1,17 @@
+export default function CorridorDetailLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 p-6">
+      <div className="h-4 w-40 rounded bg-neutral-900 animate-pulse mb-4" />
+      <div className="h-20 rounded-xl bg-neutral-900/80 animate-pulse mb-8" />
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 rounded-xl bg-neutral-900/80 animate-pulse"
+          />
+        ))}
+      </div>
+      <div className="h-64 rounded-xl bg-neutral-900/80 animate-pulse" />
+    </div>
+  );
+}

--- a/src/app/corridors/[id]/not-found.tsx
+++ b/src/app/corridors/[id]/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function CorridorNotFound() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 flex flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="text-2xl font-bold">Corridor Not Found</h1>
+      <p className="text-sm text-neutral-400 max-w-md">
+        We couldn&apos;t find a corridor matching that identifier. It may have
+        been retired or the link is out of date.
+      </p>
+      <Link
+        href="/dashboard/corridors"
+        className="text-sm font-mono text-lime-400 hover:underline"
+      >
+        &larr; Back to Corridor Monitor
+      </Link>
+    </div>
+  );
+}

--- a/src/app/corridors/[id]/page.tsx
+++ b/src/app/corridors/[id]/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getCorridorById, listCorridorIds } from "@/lib/corridors";
+import {
+  CorridorAssetIcon,
+  parseCorridorPairCodes,
+} from "@/app/dashboard/corridors/CorridorAssetIcon";
+
+interface CorridorPageProps {
+  params: Promise<{ id: string }>;
+}
+
+// Pre-render known corridors at build time; new corridors still resolve
+// on-demand via ISR since `dynamicParams` defaults to true.
+export async function generateStaticParams() {
+  const ids = await listCorridorIds();
+  return ids.map((id) => ({ id }));
+}
+
+export async function generateMetadata({
+  params,
+}: CorridorPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const corridor = await getCorridorById(id);
+
+  if (!corridor) {
+    return { title: "Corridor Not Found | StellarFlow" };
+  }
+
+  return {
+    title: `${corridor.pair} Corridor | StellarFlow`,
+    description: corridor.description,
+  };
+}
+
+const statusStyles: Record<string, string> = {
+  optimal: "bg-emerald-950/50 text-emerald-400 border-emerald-500/30",
+  degraded: "bg-amber-950/50 text-amber-400 border-amber-500/30",
+  critical: "bg-red-950/50 text-red-400 border-red-500/30",
+};
+
+export default async function CorridorDetailPage({ params }: CorridorPageProps) {
+  const { id } = await params;
+  const corridor = await getCorridorById(id);
+
+  if (!corridor) {
+    notFound();
+  }
+
+  const pairCodes = parseCorridorPairCodes(corridor.pair);
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 font-sans">
+      <Link
+        href="/dashboard/corridors"
+        className="text-xs font-mono text-neutral-400 hover:text-lime-400 transition-colors"
+      >
+        &larr; Back to Corridor Monitor
+      </Link>
+
+      <div className="mt-4 mb-8 border-b border-neutral-800 pb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+        <div className="flex items-center gap-3">
+          {pairCodes && (
+            <span className="flex items-center gap-1">
+              <CorridorAssetIcon
+                code={pairCodes[0]}
+                size={28}
+                className="text-lime-400"
+              />
+              <CorridorAssetIcon
+                code={pairCodes[1]}
+                size={28}
+                className="text-neutral-400"
+              />
+            </span>
+          )}
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">
+              {corridor.pair}
+            </h1>
+            <p className="text-sm text-neutral-400 mt-1">
+              {corridor.description}
+            </p>
+          </div>
+        </div>
+        <span
+          className={`px-3 py-1 rounded-lg text-xs font-mono border ${
+            statusStyles[corridor.status]
+          }`}
+        >
+          {corridor.status.toUpperCase()}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            IMPLIED RATE
+          </span>
+          <span className="text-2xl font-bold font-mono text-lime-400">
+            {corridor.rate.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+            })}
+          </span>
+        </div>
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            MARKET SPREAD
+          </span>
+          <span className="text-2xl font-bold font-mono text-amber-500">
+            {corridor.spread}%
+          </span>
+        </div>
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            24H VOLUME
+          </span>
+          <span className="text-2xl font-bold font-mono">
+            ${corridor.volume24h.toLocaleString()}
+          </span>
+        </div>
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            INGESTION LATENCY
+          </span>
+          <span className="text-2xl font-bold font-mono">
+            {corridor.latencyMs}ms
+          </span>
+        </div>
+      </div>
+
+      <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-5 shadow-2xl">
+        <h2 className="text-lg font-semibold mb-4 text-neutral-200">
+          Order Book Depth
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <p className="text-xs uppercase text-neutral-500 font-mono mb-2">
+              Asks
+            </p>
+            <div className="space-y-1">
+              {corridor.asks.map((ask, index) => (
+                <div
+                  key={`ask-${index}`}
+                  className="flex justify-between text-xs font-mono py-1 px-2"
+                >
+                  <span className="text-red-400">{ask.price.toFixed(2)}</span>
+                  <span className="text-neutral-300">{ask.amount}</span>
+                  <span className="text-neutral-500">{ask.total}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-neutral-500 font-mono mb-2">
+              Bids
+            </p>
+            <div className="space-y-1">
+              {corridor.bids.map((bid, index) => (
+                <div
+                  key={`bid-${index}`}
+                  className="flex justify-between text-xs font-mono py-1 px-2"
+                >
+                  <span className="text-emerald-400">
+                    {bid.price.toFixed(2)}
+                  </span>
+                  <span className="text-neutral-300">{bid.amount}</span>
+                  <span className="text-neutral-500">{bid.total}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-neutral-500 font-mono">
+          Source: {corridor.source}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/corridors/CorridorSpreadTable.tsx
+++ b/src/app/dashboard/corridors/CorridorSpreadTable.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import type { CorridorMetrics } from "../../hooks/useCorridorMetrics";
+import { corridorPairToId } from "@/lib/corridorId";
 import {
   CorridorAssetIcon,
   CorridorSpriteIcon,
@@ -87,6 +89,15 @@ const CorridorSpreadRow = React.memo(
             {item.latencyMs}ms
           </span>
         </td>
+        <td className="py-3 px-4 text-right">
+          <Link
+            href={`/corridors/${corridorPairToId(item.pair)}`}
+            onClick={(event) => event.stopPropagation()}
+            className="text-xs font-mono text-lime-400 hover:underline"
+          >
+            View &rarr;
+          </Link>
+        </td>
       </tr>
     );
   },
@@ -132,6 +143,7 @@ export default function CorridorSpreadTable({
               <th className="py-3 px-4 text-right">Market Spread</th>
               <th className="py-3 px-4 text-right">24h Vol (USDC)</th>
               <th className="py-3 px-4 text-right">Ingestion Latency</th>
+              <th className="py-3 px-4 text-right">Details</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-800/50 text-sm">

--- a/src/app/pools/[id]/loading.tsx
+++ b/src/app/pools/[id]/loading.tsx
@@ -1,0 +1,17 @@
+export default function PoolDetailLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 p-6">
+      <div className="h-4 w-40 rounded bg-neutral-900 animate-pulse mb-4" />
+      <div className="h-20 rounded-xl bg-neutral-900/80 animate-pulse mb-8" />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 rounded-xl bg-neutral-900/80 animate-pulse"
+          />
+        ))}
+      </div>
+      <div className="h-40 rounded-xl bg-neutral-900/80 animate-pulse" />
+    </div>
+  );
+}

--- a/src/app/pools/[id]/not-found.tsx
+++ b/src/app/pools/[id]/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function PoolNotFound() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 flex flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="text-2xl font-bold">Pool Not Found</h1>
+      <p className="text-sm text-neutral-400 max-w-md">
+        We couldn&apos;t find a liquidity pool matching that identifier. It may
+        have been retired or the link is out of date.
+      </p>
+      <Link href="/" className="text-sm font-mono text-lime-400 hover:underline">
+        &larr; Back to Dashboard
+      </Link>
+    </div>
+  );
+}

--- a/src/app/pools/[id]/page.tsx
+++ b/src/app/pools/[id]/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPoolById, listPoolIds } from "@/lib/pools";
+
+interface PoolPageProps {
+  params: Promise<{ id: string }>;
+}
+
+// Pre-render known pools at build time; new pools still resolve on-demand
+// via ISR since `dynamicParams` defaults to true.
+export async function generateStaticParams() {
+  const ids = await listPoolIds();
+  return ids.map((id) => ({ id }));
+}
+
+export async function generateMetadata({
+  params,
+}: PoolPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const pool = await getPoolById(id);
+
+  if (!pool) {
+    return { title: "Pool Not Found | StellarFlow" };
+  }
+
+  return {
+    title: `${pool.pair} Pool | StellarFlow`,
+    description: `Liquidity pool stats for ${pool.pair}: TVL, APR, and 24h volume.`,
+  };
+}
+
+export default async function PoolDetailPage({ params }: PoolPageProps) {
+  const { id } = await params;
+  const pool = await getPoolById(id);
+
+  if (!pool) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 font-sans">
+      <Link
+        href="/"
+        className="text-xs font-mono text-neutral-400 hover:text-lime-400 transition-colors"
+      >
+        &larr; Back to Dashboard
+      </Link>
+
+      <div className="mt-4 mb-8 border-b border-neutral-800 pb-6">
+        <h1 className="text-3xl font-bold tracking-tight">{pool.pair}</h1>
+        <p className="text-sm text-neutral-400 mt-1">
+          Automated market maker pool &middot; {pool.feePercent}% swap fee
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            TOTAL VALUE LOCKED
+          </span>
+          <span className="text-2xl font-bold font-mono text-lime-400">
+            ${pool.totalValueLocked.toLocaleString()}
+          </span>
+        </div>
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            APR
+          </span>
+          <span className="text-2xl font-bold font-mono text-emerald-400">
+            {pool.apr}%
+          </span>
+        </div>
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4">
+          <span className="text-xs font-mono text-neutral-400 block mb-1">
+            24H VOLUME
+          </span>
+          <span className="text-2xl font-bold font-mono">
+            ${pool.volume24h.toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-5 shadow-2xl">
+        <h2 className="text-lg font-semibold mb-4 text-neutral-200">
+          Pool Reserves
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="flex justify-between text-sm font-mono py-2 px-3 rounded-lg bg-neutral-950/50">
+            <span className="text-neutral-400">{pool.assetA}</span>
+            <span className="text-neutral-200">
+              {pool.reserveA.toLocaleString()}
+            </span>
+          </div>
+          <div className="flex justify-between text-sm font-mono py-2 px-3 rounded-lg bg-neutral-950/50">
+            <span className="text-neutral-400">{pool.assetB}</span>
+            <span className="text-neutral-200">
+              {pool.reserveB.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/corridorId.ts
+++ b/src/lib/corridorId.ts
@@ -1,0 +1,7 @@
+/** Slugifies a corridor pair label (e.g. "USD / NGN" -> "usd-ngn") for use as a route param. */
+export function corridorPairToId(pair: string): string {
+  return pair
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}

--- a/src/lib/corridors.ts
+++ b/src/lib/corridors.ts
@@ -1,0 +1,95 @@
+import { unstable_cache } from "next/cache";
+import { REVALIDATE_INTERVALS } from "@/config/cacheConfig";
+import type { CorridorMetrics, OrderBookEntry } from "@/app/hooks/useCorridorMetrics";
+import { corridorPairToId } from "@/lib/corridorId";
+
+export { corridorPairToId };
+
+export interface CorridorDetail extends CorridorMetrics {
+  id: string;
+  description: string;
+  bids: OrderBookEntry[];
+  asks: OrderBookEntry[];
+}
+
+function getMockCorridors(): CorridorDetail[] {
+  return [
+    {
+      id: corridorPairToId("USD / NGN"),
+      pair: "USD / NGN",
+      source: "Binance / Local B2C",
+      description:
+        "Primary fiat on/off-ramp corridor bridging USD liquidity into the Nigerian Naira retail market.",
+      rate: 1485.5,
+      spread: 0.12,
+      volume24h: 4_250_000,
+      latencyMs: 45,
+      status: "optimal",
+      bids: [
+        { price: 1485.1, amount: 2500, total: 2500 },
+        { price: 1484.8, amount: 4800, total: 7300 },
+        { price: 1484.2, amount: 12500, total: 19800 },
+      ],
+      asks: [
+        { price: 1485.9, amount: 3100, total: 3100 },
+        { price: 1486.3, amount: 6200, total: 9300 },
+        { price: 1487.0, amount: 15000, total: 24300 },
+      ],
+    },
+    {
+      id: corridorPairToId("XLM / KES"),
+      pair: "XLM / KES",
+      source: "Stellar DEX / Luno",
+      description:
+        "Stellar-native XLM corridor settling directly against Kenyan Shilling liquidity providers.",
+      rate: 16.4,
+      spread: 0.25,
+      volume24h: 1_850_000,
+      latencyMs: 120,
+      status: "optimal",
+      bids: [
+        { price: 16.35, amount: 5200, total: 5200 },
+        { price: 16.3, amount: 8100, total: 13300 },
+      ],
+      asks: [
+        { price: 16.45, amount: 4700, total: 4700 },
+        { price: 16.5, amount: 9200, total: 13900 },
+      ],
+    },
+    {
+      id: corridorPairToId("NGN / GHS"),
+      pair: "NGN / GHS",
+      source: "Cross-Corridor Implied",
+      description:
+        "Implied cross-rate derived from the NGN and GHS legs against a shared reserve asset.",
+      rate: 0.092,
+      spread: 0.68,
+      volume24h: 920_000,
+      latencyMs: 240,
+      status: "degraded",
+      bids: [{ price: 0.0915, amount: 12000, total: 12000 }],
+      asks: [{ price: 0.0925, amount: 9800, total: 9800 }],
+    },
+  ];
+}
+
+/**
+ * Cached corridor detail lookup for the `/corridors/[id]` Server Component.
+ * Shares the same revalidation cadence as the corridor monitor dashboard so
+ * the detail page and list stay consistent within a single refresh window.
+ */
+const getCachedCorridors = unstable_cache(
+  async () => getMockCorridors(),
+  ["corridor-details"],
+  { revalidate: REVALIDATE_INTERVALS.MEDIUM_INTERVAL, tags: ["corridors"] },
+);
+
+export async function listCorridorIds(): Promise<string[]> {
+  const corridors = await getCachedCorridors();
+  return corridors.map((corridor) => corridor.id);
+}
+
+export async function getCorridorById(id: string): Promise<CorridorDetail | null> {
+  const corridors = await getCachedCorridors();
+  return corridors.find((corridor) => corridor.id === id) ?? null;
+}

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -1,0 +1,83 @@
+import { unstable_cache } from "next/cache";
+import { REVALIDATE_INTERVALS } from "@/config/cacheConfig";
+
+export interface LiquidityPool {
+  id: string;
+  pair: string;
+  assetA: string;
+  assetB: string;
+  reserveA: number;
+  reserveB: number;
+  totalValueLocked: number;
+  apr: number;
+  volume24h: number;
+  feePercent: number;
+}
+
+function getMockPools(): LiquidityPool[] {
+  return [
+    {
+      id: "xlm-usdc",
+      pair: "XLM / USDC",
+      assetA: "XLM",
+      assetB: "USDC",
+      reserveA: 42_500_000,
+      reserveB: 5_100_000,
+      totalValueLocked: 10_200_000,
+      apr: 8.4,
+      volume24h: 1_850_000,
+      feePercent: 0.3,
+    },
+    {
+      id: "xlm-ngnc",
+      pair: "XLM / NGNC",
+      assetA: "XLM",
+      assetB: "NGNC",
+      reserveA: 18_200_000,
+      reserveB: 27_050_000_000,
+      totalValueLocked: 4_350_000,
+      apr: 12.1,
+      volume24h: 920_000,
+      feePercent: 0.3,
+    },
+    {
+      id: "usdc-ngnc",
+      pair: "USDC / NGNC",
+      assetA: "USDC",
+      assetB: "NGNC",
+      reserveA: 2_600_000,
+      reserveB: 3_900_000_000,
+      totalValueLocked: 5_200_000,
+      apr: 6.7,
+      volume24h: 640_000,
+      feePercent: 0.3,
+    },
+  ];
+}
+
+/**
+ * Fetches the liquidity pool registry, cached and revalidated on the same
+ * cadence as other medium-frequency market data (see `cacheProfiles`). Wrapped
+ * with `unstable_cache` so repeated Server Component renders across requests
+ * within the revalidation window reuse the same in-memory result instead of
+ * recomputing it per-request.
+ */
+const getCachedPools = unstable_cache(
+  async () => getMockPools(),
+  ["liquidity-pools"],
+  { revalidate: REVALIDATE_INTERVALS.MEDIUM_INTERVAL, tags: ["pools"] },
+);
+
+export async function listPools(): Promise<LiquidityPool[]> {
+  return getCachedPools();
+}
+
+export async function listPoolIds(): Promise<string[]> {
+  const pools = await getCachedPools();
+  return pools.map((pool) => pool.id);
+}
+
+export async function getPoolById(id: string): Promise<LiquidityPool | null> {
+  const pools = await getCachedPools();
+  return pools.find((pool) => pool.id === id) ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds `/pools/[id]` and `/corridors/[id]` as server-rendered dynamic route segments, each with `page.tsx`, `loading.tsx`, and `not-found.tsx`
- Data access (`src/lib/pools.ts`, `src/lib/corridors.ts`) is wrapped in `unstable_cache` on the same revalidation cadence as the existing corridor monitor, and both routes use `generateStaticParams` for ISR
- Corridor rows in `CorridorSpreadTable` now link through to `/corridors/[id]`
- Static marketing content (home page stats, relayer table) was already server-rendered on `main`; no changes needed there

## Note
`npm run build` currently fails on `main` (pre-existing, unrelated to this change): `Icon.tsx` and `CorridorAssetIcon.tsx` use a JSX-namespaced `xlink:href` attribute that Turbopack's SWC parser rejects (`JSX Namespace is disabled by default`). This affects the home page and most other routes app-wide, not just the ones touched here. Flagging separately rather than folding an unrelated fix into this PR.

## Test plan
- [x] `tsc --noEmit` clean on all new/changed files
- [x] `eslint` clean on all new/changed files


Closes #554