### PR TITLE
feat(toast-queue): fix #546 by adding transaction lifecycle toast notifications

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "./components/ThemeProvider";
 import { ProgressBarProvider } from "./components/TopLoadingBar";
 import { UserProvider } from "./components/providers/UserProvider";
 import { QueryProvider } from "./components/providers/QueryProvider";
+import { ToastProvider } from "@/components/ui/ToastQueue";
 import Script from "next/script";
 import SvgSprite from "@/components/icons/SvgSprite";
 
@@ -89,7 +90,9 @@ export default function RootLayout({
           <UserProvider>
             <QueryProvider>
               <ProgressBarProvider>
-                {children}
+                <ToastProvider>
+                  {children}
+                </ToastProvider>
               </ProgressBarProvider>
             </QueryProvider>
           </UserProvider>

--- a/src/app/staking/page.tsx
+++ b/src/app/staking/page.tsx
@@ -45,6 +45,7 @@ const BondAllocationCalculator = dynamic(
 );
 import Icon from '@/components/icons/Icon';
 import { ICON_IDS } from '@/components/icons/iconIds';
+import { useToast } from '@/components/ui/ToastQueue';
 
 // --- Types ---
 type StakerNode = StakerTableRecord;
@@ -58,6 +59,7 @@ const MOCK_STAKERS: StakerNode[] = [
 ];
 
 export default function StakingPage() {
+  const { addToast, updateToast } = useToast();
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearch = useDebounce(searchTerm, 250);
   const throttledSetSearchTerm = useRafThrottle((v: string) => setSearchTerm(v));
@@ -79,11 +81,27 @@ export default function StakingPage() {
     if (isSubmitting) return;
     setIsSubmitting(true);
     setConfirmationMsg('Loading secure environment...');
+    const toastId = addToast({
+      title: 'Transaction submitted',
+      description: 'Preparing staking allocation transaction for submission.',
+      status: 'submitted',
+    });
     try {
       const { submitTransaction } = await import('@/lib/transactionOps');
       setConfirmationMsg('Allocation confirmed. Submitting to network…');
+      updateToast(toastId, {
+        status: 'processing',
+        title: 'Transaction processing',
+        description: 'Your staking transaction is being submitted to the network.',
+      });
       const txHash = await submitTransaction(allocations);
       setConfirmationMsg(`Transaction successful: ${txHash}`);
+      updateToast(toastId, {
+        status: 'confirmed',
+        title: 'Transaction confirmed',
+        description: 'Your staking allocation was confirmed on-chain.',
+        txHash,
+      });
       
       const timer1 = setTimeout(() => {
         setConfirmationMsg(null);
@@ -92,6 +110,11 @@ export default function StakingPage() {
       timeoutsRef.current.add(timer1);
     } catch (err) {
       setConfirmationMsg('Transaction failed');
+      updateToast(toastId, {
+        status: 'failed',
+        title: 'Transaction failed',
+        description: err instanceof Error ? err.message : 'The staking transaction could not be completed.',
+      });
       const timer2 = setTimeout(() => {
         setConfirmationMsg(null);
         timeoutsRef.current.delete(timer2);
@@ -100,7 +123,7 @@ export default function StakingPage() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [isSubmitting]);
+  }, [addToast, isSubmitting, updateToast]);
 
   const displayedStakers = useMemo(() => {
     const q = debouncedSearch.trim().toLowerCase();

--- a/src/components/escrow/ClaimEscrowModal.tsx
+++ b/src/components/escrow/ClaimEscrowModal.tsx
@@ -5,6 +5,7 @@ import OptimizedDialog from "@/app/components/OptimizedDialog";
 import { useRAFInterval } from "@/app/hooks/useRAFInterval";
 import Icon from "@/components/icons/Icon";
 import { ICON_IDS } from "@/components/icons/iconIds";
+import { useToast } from "@/components/ui/ToastQueue";
 import { formatCountdown, validatePreimageHex } from "@/lib/hexValidation";
 
 export interface ClaimEscrowModalProps {
@@ -35,6 +36,7 @@ export function ClaimEscrowModal({
   onClaimSuccess,
   onClaimError,
 }: ClaimEscrowModalProps) {
+  const { addToast, updateToast } = useToast();
   const [preimage, setPreimage] = useState("");
   const [touched, setTouched] = useState(false);
   const [remainingMs, setRemainingMs] = useState(() =>
@@ -55,20 +57,20 @@ export function ClaimEscrowModal({
 
   useEffect(() => {
     if (!isOpen) return;
-    updateRemaining();
+    const initialSyncTimer = window.setTimeout(updateRemaining, 0);
+    return () => window.clearTimeout(initialSyncTimer);
   }, [isOpen, updateRemaining]);
 
   useRAFInterval(updateRemaining, 1000, isOpen);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setPreimage("");
-      setTouched(false);
-      setSubmitError(null);
-      setTxHash(null);
-      setIsSubmitting(false);
-    }
-  }, [isOpen]);
+  const handleClose = useCallback(() => {
+    setPreimage("");
+    setTouched(false);
+    setSubmitError(null);
+    setTxHash(null);
+    setIsSubmitting(false);
+    onClose();
+  }, [onClose]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -81,8 +83,18 @@ export function ClaimEscrowModal({
     }
 
     setIsSubmitting(true);
+    const toastId = addToast({
+      title: "Escrow claim submitted",
+      description: "Submitting your HTLC claim to the network.",
+      status: "submitted",
+    });
 
     try {
+      updateToast(toastId, {
+        status: "processing",
+        title: "Escrow claim processing",
+        description: "Your claim transaction is being prepared and sent.",
+      });
       const { claimEscrow } = await import("@/lib/escrowOps");
       const { txHash: hash } = await claimEscrow({
         contractId,
@@ -90,11 +102,22 @@ export function ClaimEscrowModal({
       });
 
       setTxHash(hash);
+      updateToast(toastId, {
+        status: "confirmed",
+        title: "Escrow claim confirmed",
+        description: "Your claim was confirmed on-chain.",
+        txHash: hash,
+      });
       onClaimSuccess?.(hash);
     } catch (err) {
       const error =
         err instanceof Error ? err : new Error("Failed to claim escrow funds.");
       setSubmitError(error.message);
+      updateToast(toastId, {
+        status: "failed",
+        title: "Escrow claim failed",
+        description: error.message,
+      });
       onClaimError?.(error);
     } finally {
       setIsSubmitting(false);
@@ -104,7 +127,7 @@ export function ClaimEscrowModal({
   return (
     <OptimizedDialog
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       title="Claim HTLC Escrow"
       size="lg"
     >

--- a/src/components/ui/ToastQueue.tsx
+++ b/src/components/ui/ToastQueue.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import Icon from "@/components/icons/Icon";
+import { ICON_IDS, IconId } from "@/components/icons/iconIds";
+
+export type ToastStatus = "submitted" | "processing" | "confirmed" | "failed";
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  status: ToastStatus;
+  txHash?: string;
+  createdAt: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, "id" | "createdAt">) => string;
+  updateToast: (id: string, updates: Partial<Omit<Toast, "id" | "createdAt">>) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timeouts = useRef<Record<string, NodeJS.Timeout>>({});
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    if (timeouts.current[id]) {
+      clearTimeout(timeouts.current[id]);
+      delete timeouts.current[id];
+    }
+  }, []);
+
+  const addToast = useCallback((toast: Omit<Toast, "id" | "createdAt">) => {
+    const id = Math.random().toString(36).substring(2, 9);
+    const newToast: Toast = {
+      ...toast,
+      id,
+      createdAt: Date.now(),
+    };
+
+    setToasts((prev) => [...prev, newToast]);
+
+    // Auto-dismiss successful (confirmed) toasts after 5 seconds
+    if (toast.status === "confirmed") {
+      timeouts.current[id] = setTimeout(() => {
+        removeToast(id);
+      }, 5000);
+    }
+
+    return id;
+  }, [removeToast]);
+
+  const updateToast = useCallback((id: string, updates: Partial<Omit<Toast, "id" | "createdAt">>) => {
+    setToasts((prev) =>
+      prev.map((t) => {
+        if (t.id !== id) return t;
+        const updated = { ...t, ...updates };
+
+        // Handle auto-dismissal if status transitions to confirmed
+        if (updates.status === "confirmed") {
+          if (timeouts.current[id]) clearTimeout(timeouts.current[id]);
+          timeouts.current[id] = setTimeout(() => {
+            removeToast(id);
+          }, 5000);
+        }
+
+        return updated;
+      })
+    );
+  }, [removeToast]);
+
+  // Clean up timeouts on unmount
+  useEffect(() => {
+    return () => {
+      Object.values(timeouts.current).forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, updateToast, removeToast }}>
+      {children}
+      <ToastQueue toasts={toasts} removeToast={removeToast} />
+    </ToastContext.Provider>
+  );
+}
+
+function ToastQueue({ toasts, removeToast }: { toasts: Toast[]; removeToast: (id: string) => void }) {
+  return (
+    <div
+      className="fixed bottom-6 right-6 z-50 flex flex-col gap-3 w-full max-w-sm pointer-events-none"
+      role="region"
+      aria-label="Notifications"
+    >
+      <AnimatePresence>
+        {toasts.map((toast) => (
+          <motion.div
+            key={toast.id}
+            layout
+            initial={{ opacity: 0, y: 50, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.85, transition: { duration: 0.2 } }}
+            className="pointer-events-auto w-full"
+          >
+            <ToastCard toast={toast} onClose={() => removeToast(toast.id)} />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function ToastCard({ toast, onClose }: { toast: Toast; onClose: () => void }) {
+  const { title, description, status, txHash } = toast;
+
+  // Visual variants depending on transaction lifecycle status
+  let statusColor = "text-blue-400";
+  let borderColor = "border-blue-900/40";
+  let bgColor = "bg-blue-950/20";
+  let iconId: IconId = ICON_IDS.activity;
+
+  if (status === "processing") {
+    statusColor = "text-amber-400";
+    borderColor = "border-amber-900/40";
+    bgColor = "bg-amber-950/20";
+    iconId = ICON_IDS.refreshCcw;
+  } else if (status === "confirmed") {
+    statusColor = "text-emerald-400";
+    borderColor = "border-emerald-800/40";
+    bgColor = "bg-emerald-950/30";
+    iconId = ICON_IDS.checkCircle;
+  } else if (status === "failed") {
+    statusColor = "text-rose-400";
+    borderColor = "border-rose-900/40";
+    bgColor = "bg-rose-950/20";
+    iconId = ICON_IDS.xCircle;
+  }
+
+  const explorerUrl = txHash ? `https://stellar.expert/explorer/testnet/tx/${txHash}` : null;
+
+  return (
+    <div
+      className={`flex items-start gap-4 p-4 rounded-xl border backdrop-blur-md ${bgColor} ${borderColor} shadow-2xl relative group overflow-hidden`}
+    >
+      {/* Visual Accent/Glow */}
+      <div className={`absolute top-0 left-0 bottom-0 w-1 ${status === "confirmed" ? "bg-emerald-500" : status === "processing" ? "bg-amber-500" : status === "failed" ? "bg-rose-500" : "bg-blue-500"}`} />
+
+      {/* Icon Section */}
+      <div className={`shrink-0 p-1.5 rounded-lg ${statusColor} bg-white/5`}>
+        <Icon
+          id={iconId}
+          size={20}
+          className={`${status === "processing" ? "animate-spin" : ""}`}
+        />
+      </div>
+
+      {/* Content Section */}
+      <div className="flex-1 min-w-0 pr-4">
+        <h4 className="text-sm font-semibold text-white tracking-tight truncate">
+          {title}
+        </h4>
+        {description && (
+          <p className="text-xs text-gray-400 mt-1 leading-relaxed break-words">
+            {description}
+          </p>
+        )}
+
+        {/* Explorer Link */}
+        {explorerUrl && (
+          <div className="mt-2 flex items-center gap-1">
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-[#CBF34D] hover:underline cursor-pointer"
+            >
+              <span>View on Stellar Expert</span>
+              <Icon id={ICON_IDS.externalLink} size={12} strokeWidth={2.5} />
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-3 right-3 text-gray-500 hover:text-gray-300 transition-colors p-1 rounded-md hover:bg-white/5"
+        aria-label="Close notification"
+      >
+        <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5">
+          <line x1="1" y1="1" x2="13" y2="13"></line>
+          <line x1="13" y1="1" x2="1" y2="13"></line>
+        </svg>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #546 

# Summary
This change addresses issue #546 by implementing a reusable toast queue for transaction feedback and wiring it into the active submission flows.

Before this update, transaction actions only surfaced status inline in their own screens, which made it easy to miss pending work and did not provide a consistent non-blocking notification experience. The new flow now shows floating toasts in the bottom-right corner for submission, processing, confirmation, and failure states. Confirmed toasts include a direct transaction hash link to Stellar Expert and auto-dismiss after 5 seconds.

The implementation matters because users now get immediate feedback during wallet-driven operations without losing context in the page they are already using. It also improves trust and transparency by exposing the transaction lifecycle in a predictable, reusable UI pattern.

Key implementation details:
- Added a client-side toast provider and queue in `src/components/ui/ToastQueue.tsx`.
- Kept the queue globally available by mounting the provider in the app layout.
- Integrated toast lifecycle updates into staking transaction submission.
- Integrated toast lifecycle updates into HTLC escrow claim submission.
- Ensured successful toasts auto-dismiss after 5 seconds and include an explorer link when a transaction hash is available.

# Changes Made
- `src/components/ui/ToastQueue.tsx`
  - Added the toast queue provider, toast state model, lifecycle statuses, and bottom-right floating toast rendering.
  - Added explorer links for transactions when `txHash` is present.
  - Added auto-dismiss behavior for confirmed toasts after 5 seconds.
- `src/app/layout.tsx`
  - Mounted `ToastProvider` so the queue is available across the app.
- `src/app/staking/page.tsx`
  - Added `submitted`, `processing`, `confirmed`, and `failed` toast updates around staking submission.
  - Kept the existing inline status messaging intact.
- `src/components/escrow/ClaimEscrowModal.tsx`
  - Added `submitted`, `processing`, `confirmed`, and `failed` toast updates around escrow claims.
  - Removed the effect-driven reset path and moved reset behavior into the close handler to satisfy hook linting.
- Issue reference:
  - Implements the requested toast notification queue for #546.

# Testing
Executed validation:
- `npm test`
  - Result: passed.
  - Output summary: `All langCache checks passed`
- `npx eslint src/app/staking/page.tsx src/components/escrow/ClaimEscrowModal.tsx src/components/ui/ToastQueue.tsx`
  - Result: passed with warnings only, no errors.
