### PR TITLE
Feature/568 vercel ci preview deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,3 +50,81 @@ jobs:
 
       - name: Unit tests
         run: npm run test
+
+# ─────────────────────────────────────────────
+# Job 2 — Vercel Preview Deployment (pull requests only)
+# Deploys to a per-PR preview environment on Vercel.
+# Outputs the deployment URL for use in the comment job.
+# ─────────────────────────────────────────────
+  preview:
+    name: Vercel — Preview deployment
+    runs-on: ubuntu-latest
+    needs: quality
+    # Only run on pull-request events, not on tag pushes.
+    if: github.event_name == 'pull_request'
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.preview_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment (preview)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project (preview)
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (preview)
+        id: deploy
+        run: |
+          PREVIEW_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+# ─────────────────────────────────────────────
+# Job 3 — Vercel Production Deployment (version tags only)
+# Deploys to the Vercel production target when a v* tag is pushed.
+# ─────────────────────────────────────────────
+  production:
+    name: Vercel — Production deployment
+    runs-on: ubuntu-latest
+    needs: quality
+    # Only run when the trigger is a version tag, not on PRs.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment (production)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project (production)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (production)
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Vercel CI — Preview & Production
+
+# ─────────────────────────────────────────────
+# Triggers
+#   • pull_request  → preview deployment
+#   • push tag v*   → production deployment
+# ─────────────────────────────────────────────
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    tags:
+      - "v*"
+
+# Cancel in-flight runs for the same PR / branch so we don't waste minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "20"
+
+# ─────────────────────────────────────────────
+# Job 1 — Quality checks (lint · typecheck · test)
+# Runs on every PR and every version tag push.
+# ─────────────────────────────────────────────
+jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      - name: Type-check (tsc --noEmit)
+        run: npx tsc --noEmit
+
+      - name: Unit tests
+        run: npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,3 +128,73 @@ jobs:
 
       - name: Deploy to Vercel (production)
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+# ─────────────────────────────────────────────
+# Job 4 — Post preview URL as a PR comment
+# Runs only on pull requests, after the preview deployment succeeds.
+# Uses github-script to find-or-update an existing bot comment so the
+# PR thread stays clean (no duplicate comments on re-runs).
+# ─────────────────────────────────────────────
+  comment:
+    name: Post preview URL comment
+    runs-on: ubuntu-latest
+    needs: preview
+    # Only runs when the preview job ran (i.e. on pull_request events).
+    if: github.event_name == 'pull_request'
+    # Needs write permission to create/update issue comments.
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Find existing preview comment
+        uses: actions/github-script@v7
+        id: find-comment
+        with:
+          script: |
+            const marker = '<!-- vercel-preview-comment -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            return existing ? existing.id : null;
+
+      - name: Create or update preview URL comment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ needs.preview.outputs.preview_url }}
+        with:
+          script: |
+            const marker = '<!-- vercel-preview-comment -->';
+            const sha     = context.payload.pull_request.head.sha.substring(0, 7);
+            const body    = [
+              marker,
+              '## 🔍 Vercel Preview Deployment',
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **Preview URL** | [${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL}) |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Status** | ✅ Ready |`,
+              '',
+              '_This comment is updated automatically on every push to this PR._',
+            ].join('\n');
+
+            const commentId = ${{ steps.find-comment.outputs.result }};
+
+            if (commentId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
  ## ci(#568): Vercel CI — Automated Preview & Production Deployment Pipeline
  
  ### Summary
  
  Implements the full GitHub Actions CI/CD pipeline for automated Vercel deployments as specified in issue #568. The workflow enforces quality gates before any deployment and provides automatic
  preview feedback directly on pull requests.
  
  ---
  
  ### Changes
  
  **New file:** `.github/workflows/deploy.yml`
  
  ---
  
  ### Pipeline Architecture
  
  The workflow defines four sequential jobs with strict dependency ordering:
  
  pull_request ──► quality ──► preview ──► comment
  push (v* tag) ──► quality ──► production
  
  **Job 1 — `quality`** (gate for all deployments)
  Runs on every PR event and every `v*` tag push. No deployment job can proceed unless all three checks pass.
  - ESLint via `npm run lint`
  - TypeScript type-check via `npx tsc --noEmit`
  - Unit tests via `npm run test`
  
  **Job 2 — `preview`** (PRs only)
  Triggered on `pull_request` after `quality` passes. Uses the official Vercel CLI to pull the preview environment configuration, build the project, and deploy. Captures the live preview URL as
  a job output.
  
  **Job 3 — `production`** (version tags only)
  Triggered on `push` to tags matching `v*` after `quality` passes. Deploys to the Vercel production target using `--prod`. Completely isolated from the PR preview flow.
  
  **Job 4 — `comment`** (PRs only)
  Runs after `preview` succeeds. Uses `actions/github-script` to post the preview URL as a formatted comment on the PR. On subsequent pushes to the same PR, the existing comment is updated in
  place — no duplicate comments.
  
  ---
  
  ### Key Design Decisions
  
  | Decision | Rationale |
  |---|---|
  | `needs: quality` on both deploy jobs | Deployments are hard-blocked if lint, types, or tests fail |
  | `concurrency` group with `cancel-in-progress` | Prevents redundant parallel runs on rapid pushes, saves CI minutes |
  | Find-or-update comment pattern | Keeps the PR thread clean across multiple commits |
  | `npm ci` instead of `npm install` | Reproducible, lock-file-strict installs in CI |
  | Pinned action versions (`@v4`, `@v7`) | Prevents unexpected breakage from upstream action updates |
  
  ---
  
  ### Required Setup (Repo Secrets)
  
  Before the workflow is functional, the following secret must be added under **Settings → Secrets and variables → Actions**:
  
  | Secret | Description |
  |---|---|
  | `VERCEL_TOKEN` | Personal or team API token from [vercel.com/account/tokens](https://vercel.com/account/tokens) |
  
  The `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are picked up automatically from `.vercel/project.json` generated by running `vercel link` locally.
  
  ---
  
  ### Testing
  
  - Workflow YAML validated for correct job dependency graph and conditional logic
  - `if` conditions confirmed to correctly isolate `preview`/`comment` to PR events and `production` to tag push events
  - Comment find-or-update logic tested against the GitHub REST API shape
  
  ---
  
  ### Commits
  
  | SHA | Message |
  |---|---|
  | `9c85a66` | `ci(#568): add quality checks job (lint, typecheck, test)` |
  | `f7156b8` | `ci(#568): add Vercel preview and production deployment jobs` |
  | `6c88885` | `ci(#568): add PR comment job to post Vercel preview URL` |

Closes #568