### PR TITLE
Feat/custom token

### DIFF
--- a/src/app/components/providers/NetworkProvider.tsx
+++ b/src/app/components/providers/NetworkProvider.tsx
@@ -11,7 +11,7 @@
  * Slices
  * ──────
  *  • NetworkStateContext   — the selected `NetworkTarget` and memoised SDK
- *                            clients (Horizon.Server + SorobanRpc.Server).
+ *                            clients (Horizon.Server + rpc.Server).
  *  • NetworkStatusContext  — whether a client re-instantiation is in-flight
  *                            and any error string.
  *  • NetworkActionsContext — stable `switchNetwork` callback; identity never
@@ -93,7 +93,7 @@ const DEFAULT_NETWORK: NetworkTarget = "testnet";
 export interface StellarClients {
   /** `Horizon.Server` instance pointed at the active network */
   horizon: HorizonServerLike;
-  /** `SorobanRpc.Server` instance pointed at the active network */
+  /** `rpc.Server` instance pointed at the active network */
   soroban: SorobanServerLike;
   /** The `NetworkTarget` these clients belong to — for double-checking */
   network: NetworkTarget;
@@ -123,7 +123,7 @@ interface StellarSdkModule {
   Horizon: {
     Server: new (url: string) => HorizonServerLike;
   };
-  SorobanRpc: {
+  rpc: {
     Server: new (url: string, opts?: { allowHttp?: boolean }) => SorobanServerLike;
   };
 }
@@ -141,7 +141,7 @@ function buildClients(network: NetworkTarget, sdk: StellarSdkModule): StellarCli
   const cfg = NETWORK_CONFIGS[network];
   return {
     horizon: new sdk.Horizon.Server(cfg.horizonUrl),
-    soroban: new sdk.SorobanRpc.Server(cfg.sorobanRpcUrl, { allowHttp: false }),
+    soroban: new sdk.rpc.Server(cfg.sorobanRpcUrl, { allowHttp: false }),
     network,
   };
 }

--- a/src/components/tokens/ImportTokenModal.tsx
+++ b/src/components/tokens/ImportTokenModal.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import OptimizedDialog from "@/app/components/OptimizedDialog";
+import Icon from "@/components/icons/Icon";
+import { ICON_IDS } from "@/components/icons/iconIds";
+import {
+  fetchTokenMetadata,
+  isTokenImported,
+  saveCustomToken,
+  validateAssetInput,
+  validateContractId,
+  type CustomToken,
+  type TokenImportInput,
+  type TokenMetadata,
+} from "@/lib/customTokens";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ImportMode = "contract" | "asset";
+
+export interface ImportTokenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called after a token is successfully persisted to local storage. */
+  onImport?: (token: CustomToken) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ImportTokenModal({
+  isOpen,
+  onClose,
+  onImport,
+}: ImportTokenModalProps) {
+  // ── Input state ────────────────────────────────────────────────────────────
+  const [mode, setMode] = useState<ImportMode>("contract");
+  const [contractId, setContractId] = useState("");
+  const [assetCode, setAssetCode] = useState("");
+  const [assetIssuer, setAssetIssuer] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  // ── Resolution state ───────────────────────────────────────────────────────
+  const [isFetching, setIsFetching] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [metadata, setMetadata] = useState<TokenMetadata | null>(null);
+
+  // ── Risk acknowledgement / import state ────────────────────────────────────
+  const [riskAcknowledged, setRiskAcknowledged] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [imported, setImported] = useState(false);
+
+  // ── Derived input model ────────────────────────────────────────────────────
+  const importInput = useMemo<TokenImportInput>(
+    () =>
+      mode === "contract"
+        ? { mode, contractId }
+        : { mode, code: assetCode, issuer: assetIssuer },
+    [mode, contractId, assetCode, assetIssuer],
+  );
+
+  const validation = useMemo(
+    () =>
+      mode === "contract"
+        ? validateContractId(contractId)
+        : validateAssetInput(assetCode, assetIssuer),
+    [mode, contractId, assetCode, assetIssuer],
+  );
+
+  const alreadyImported = useMemo(
+    () => (metadata ? isTokenImported(metadata.contractId) : false),
+    [metadata],
+  );
+
+  // ── Reset on close ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isOpen) {
+      setMode("contract");
+      setContractId("");
+      setAssetCode("");
+      setAssetIssuer("");
+      setTouched(false);
+      setIsFetching(false);
+      setFetchError(null);
+      setMetadata(null);
+      setRiskAcknowledged(false);
+      setImportError(null);
+      setImported(false);
+    }
+  }, [isOpen]);
+
+  // Any input change invalidates a previously resolved token so the user must
+  // re-fetch and re-acknowledge before importing a different asset.
+  const resetResolution = useCallback(() => {
+    setMetadata(null);
+    setFetchError(null);
+    setImportError(null);
+    setRiskAcknowledged(false);
+    setImported(false);
+  }, []);
+
+  const switchMode = useCallback(
+    (next: ImportMode) => {
+      if (next === mode) return;
+      setMode(next);
+      setTouched(false);
+      resetResolution();
+    },
+    [mode, resetResolution],
+  );
+
+  // ── Metadata resolution ────────────────────────────────────────────────────
+  const handleFetch = useCallback(async () => {
+    setTouched(true);
+    setFetchError(null);
+    setImportError(null);
+
+    if (!validation.valid) {
+      return;
+    }
+
+    setIsFetching(true);
+    setMetadata(null);
+    setRiskAcknowledged(false);
+    try {
+      const result = await fetchTokenMetadata(importInput);
+      setMetadata(result);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Could not resolve token metadata from the network.";
+      setFetchError(message);
+    } finally {
+      setIsFetching(false);
+    }
+  }, [validation.valid, importInput]);
+
+  // ── Import commit ──────────────────────────────────────────────────────────
+  const handleImport = useCallback(() => {
+    setImportError(null);
+    if (!metadata) {
+      setImportError("Resolve the token metadata before importing.");
+      return;
+    }
+    if (!riskAcknowledged) {
+      setImportError("You must acknowledge the risk warning before importing.");
+      return;
+    }
+
+    try {
+      const next = saveCustomToken(metadata);
+      const saved = next.find((t) => t.contractId === metadata.contractId);
+      setImported(true);
+      if (saved) onImport?.(saved);
+    } catch {
+      setImportError("Failed to save the token to local storage.");
+    }
+  }, [metadata, riskAcknowledged, onImport]);
+
+  const inputError = touched ? validation.error : null;
+  const canFetch = validation.valid && !isFetching;
+  const canImport = metadata !== null && riskAcknowledged && !imported;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <OptimizedDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Import Custom Token"
+      size="lg"
+    >
+      <div className="space-y-5">
+        {/* ── Mode toggle ─────────────────────────────────────────────────── */}
+        <div
+          className="grid grid-cols-2 gap-2 rounded-lg border border-gray-800 bg-[#0d1117] p-1"
+          role="tablist"
+          aria-label="Import method"
+        >
+          {(
+            [
+              { key: "contract", label: "Contract Address" },
+              { key: "asset", label: "Asset Code + Issuer" },
+            ] as const
+          ).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={mode === key}
+              onClick={() => switchMode(key)}
+              className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                mode === key
+                  ? "bg-blue-600 text-white"
+                  : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Input fields ────────────────────────────────────────────────── */}
+        {mode === "contract" ? (
+          <div className="space-y-1.5">
+            <label
+              htmlFor="import-contract-id"
+              className="text-xs uppercase font-bold text-gray-500"
+            >
+              Contract Address
+            </label>
+            <input
+              id="import-contract-id"
+              type="text"
+              value={contractId}
+              onChange={(e) => {
+                setContractId(e.target.value);
+                resetResolution();
+              }}
+              onBlur={() => setTouched(true)}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder="C… (56-character Stellar contract address)"
+              disabled={isFetching}
+              className="w-full rounded-lg border border-gray-700 bg-[#0d1117] px-3 py-2.5 font-mono text-sm text-gray-200 placeholder:text-gray-600 focus:border-blue-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              aria-invalid={inputError !== null}
+              aria-describedby={inputError ? "import-input-error" : undefined}
+            />
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="import-asset-code"
+                className="text-xs uppercase font-bold text-gray-500"
+              >
+                Asset Code
+              </label>
+              <input
+                id="import-asset-code"
+                type="text"
+                value={assetCode}
+                onChange={(e) => {
+                  setAssetCode(e.target.value);
+                  resetResolution();
+                }}
+                onBlur={() => setTouched(true)}
+                spellCheck={false}
+                autoComplete="off"
+                placeholder="e.g. USDC"
+                disabled={isFetching}
+                maxLength={12}
+                className="w-full rounded-lg border border-gray-700 bg-[#0d1117] px-3 py-2.5 font-mono text-sm text-gray-200 placeholder:text-gray-600 focus:border-blue-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                aria-invalid={inputError !== null}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label
+                htmlFor="import-asset-issuer"
+                className="text-xs uppercase font-bold text-gray-500"
+              >
+                Issuer Address
+              </label>
+              <input
+                id="import-asset-issuer"
+                type="text"
+                value={assetIssuer}
+                onChange={(e) => {
+                  setAssetIssuer(e.target.value);
+                  resetResolution();
+                }}
+                onBlur={() => setTouched(true)}
+                spellCheck={false}
+                autoComplete="off"
+                placeholder="G… (56-character issuer public key)"
+                disabled={isFetching}
+                className="w-full rounded-lg border border-gray-700 bg-[#0d1117] px-3 py-2.5 font-mono text-sm text-gray-200 placeholder:text-gray-600 focus:border-blue-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                aria-invalid={inputError !== null}
+                aria-describedby={inputError ? "import-input-error" : undefined}
+              />
+            </div>
+          </div>
+        )}
+
+        {inputError && (
+          <p id="import-input-error" className="text-xs text-red-400" role="alert">
+            {inputError}
+          </p>
+        )}
+
+        {/* ── Fetch metadata ──────────────────────────────────────────────── */}
+        {!metadata && (
+          <button
+            type="button"
+            onClick={handleFetch}
+            disabled={!canFetch}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-700 bg-[#0d1117] px-4 py-2.5 text-sm font-medium text-gray-200 transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isFetching ? (
+              <>
+                <span
+                  className="h-3.5 w-3.5 shrink-0 rounded-full border-2 border-current border-t-transparent animate-spin"
+                  aria-hidden="true"
+                />
+                Resolving token metadata…
+              </>
+            ) : (
+              <>
+                <Icon
+                  id={ICON_IDS.search}
+                  size={15}
+                  className="text-gray-400 shrink-0"
+                />
+                Fetch Token Details
+              </>
+            )}
+          </button>
+        )}
+
+        {fetchError && (
+          <div
+            className="rounded-lg border border-red-500/40 bg-red-950/20 px-3 py-2 text-sm text-red-300"
+            role="alert"
+          >
+            {fetchError}
+          </div>
+        )}
+
+        {/* ── Resolved metadata ───────────────────────────────────────────── */}
+        {metadata && (
+          <div className="rounded-lg border border-gray-800 bg-[#0d1117] p-4 space-y-3">
+            <p className="text-xs uppercase font-bold tracking-wider text-gray-400 flex items-center gap-1.5">
+              <Icon id={ICON_IDS.coins} size={14} className="text-blue-400" />
+              Token Details
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <p className="text-xs text-gray-500">Name</p>
+                <p className="mt-0.5 text-sm font-semibold text-gray-100 break-words">
+                  {metadata.name || "—"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Symbol</p>
+                <p className="mt-0.5 text-sm font-semibold text-gray-100 break-words">
+                  {metadata.symbol || "—"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Decimals</p>
+                <p className="mt-0.5 font-mono text-sm text-gray-200">
+                  {metadata.decimals}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Contract</p>
+                <p className="mt-0.5 font-mono text-xs text-gray-300 break-all">
+                  {metadata.contractId.slice(0, 6)}…
+                  {metadata.contractId.slice(-6)}
+                </p>
+              </div>
+            </div>
+            {metadata.issuer && (
+              <div className="border-t border-gray-800 pt-2">
+                <p className="text-xs text-gray-500">Issuer</p>
+                <p className="mt-0.5 font-mono text-xs text-gray-300 break-all">
+                  {metadata.issuer}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── Unverified-asset security warning ───────────────────────────── */}
+        {metadata && !imported && (
+          <div className="rounded-lg border border-yellow-500/40 bg-yellow-950/10 p-4 space-y-3">
+            <div className="flex items-start gap-2">
+              <Icon
+                id={ICON_IDS.shieldAlert}
+                size={18}
+                className="text-yellow-400 shrink-0 mt-0.5"
+              />
+              <div className="space-y-1.5">
+                <p className="text-sm font-semibold text-yellow-300">
+                  Unverified asset — import at your own risk
+                </p>
+                <ul className="list-disc space-y-1 pl-4 text-xs text-yellow-200/80">
+                  <li>
+                    Anyone can create a token using any name or symbol, including
+                    ones that impersonate trusted assets.
+                  </li>
+                  <li>
+                    StellarFlow has <span className="font-semibold">not</span>{" "}
+                    verified this contract. It may be malicious, worthless, or
+                    unable to be sold.
+                  </li>
+                  <li>
+                    Always confirm the contract address from a source you trust
+                    before interacting with this token.
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {alreadyImported && (
+              <p className="flex items-center gap-1.5 text-xs text-gray-400">
+                <Icon
+                  id={ICON_IDS.checkCircle}
+                  size={13}
+                  className="text-gray-500 shrink-0"
+                />
+                This token is already in your list. Importing again will refresh
+                its details.
+              </p>
+            )}
+
+            <label className="flex cursor-pointer items-start gap-2.5 rounded-md border border-yellow-500/20 bg-[#0d1117]/60 px-3 py-2.5">
+              <input
+                type="checkbox"
+                checked={riskAcknowledged}
+                onChange={(e) => {
+                  setRiskAcknowledged(e.target.checked);
+                  setImportError(null);
+                }}
+                className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-yellow-500"
+                aria-describedby="import-risk-label"
+              />
+              <span id="import-risk-label" className="text-xs text-gray-200">
+                I understand this is an unverified token and I accept the risks
+                of importing it.
+              </span>
+            </label>
+          </div>
+        )}
+
+        {importError && (
+          <div
+            className="rounded-lg border border-red-500/40 bg-red-950/20 px-3 py-2 text-sm text-red-300"
+            role="alert"
+          >
+            {importError}
+          </div>
+        )}
+
+        {/* ── Success ─────────────────────────────────────────────────────── */}
+        {imported && metadata && (
+          <div className="rounded-lg border border-emerald-500/40 bg-emerald-950/20 px-3 py-2 text-sm text-emerald-300 flex items-center gap-2">
+            <Icon
+              id={ICON_IDS.checkCircle}
+              size={15}
+              className="text-emerald-400 shrink-0"
+            />
+            <span>
+              <span className="font-semibold">{metadata.symbol}</span> imported
+              and saved to this browser.
+            </span>
+          </div>
+        )}
+
+        {/* ── Action row ──────────────────────────────────────────────────── */}
+        <div className="flex justify-end gap-3 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+          >
+            {imported ? "Close" : "Cancel"}
+          </button>
+          {!imported && (
+            <button
+              type="button"
+              onClick={handleImport}
+              disabled={!canImport}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Import Token
+            </button>
+          )}
+        </div>
+      </div>
+    </OptimizedDialog>
+  );
+}
+
+export default ImportTokenModal;

--- a/src/components/tokens/index.ts
+++ b/src/components/tokens/index.ts
@@ -1,0 +1,4 @@
+export {
+  ImportTokenModal,
+  type ImportTokenModalProps,
+} from "./ImportTokenModal";

--- a/src/lib/customTokens.ts
+++ b/src/lib/customTokens.ts
@@ -1,0 +1,304 @@
+/**
+ * Custom token import library.
+ *
+ * Two responsibilities, kept out of the initial bundle where possible:
+ *
+ *  1. Pure, synchronous input validation + local-storage persistence for
+ *     user-imported custom tokens (no SDK — safe to run on every keystroke).
+ *  2. On-demand metadata resolution against Soroban RPC / Horizon. The
+ *     Stellar SDK is lazy-loaded inside {@link fetchTokenMetadata} so it is
+ *     only fetched when the user explicitly resolves a token.
+ *
+ * A "custom token" is any Stellar Asset Contract (SAC) or SEP-41 token that
+ * the user chose to import manually. These are inherently **unverified** —
+ * they are not part of any curated allow-list — so every persisted record is
+ * flagged accordingly for the UI to surface a security warning.
+ */
+
+import { getItem, setItem } from "@/utils/storage";
+
+const SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+const SIMULATION_FEE = "100";
+const STORAGE_KEY = "stellarflow.customTokens.v1";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A user-imported custom token persisted to local browser storage. */
+export interface CustomToken {
+  /** Soroban contract address (SAC/SEP-41) — the canonical identifier. */
+  contractId: string;
+  /** Token symbol / asset code (e.g. "USDC"). */
+  symbol: string;
+  /** Human-readable token name. */
+  name: string;
+  /** On-chain decimal precision. */
+  decimals: number;
+  /** Classic asset issuer, present only for code+issuer imports. */
+  issuer?: string;
+  /** Epoch ms when the user imported this token. */
+  addedAt: number;
+  /**
+   * Always `false` for manually imported tokens. Persisted explicitly so the
+   * UI can render the unverified-asset warning without re-deriving trust.
+   */
+  verified: boolean;
+}
+
+/** Metadata resolved from the network before an import is committed. */
+export interface TokenMetadata {
+  contractId: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  issuer?: string;
+}
+
+/** Import by raw Soroban contract address. */
+export interface ContractImportInput {
+  mode: "contract";
+  contractId: string;
+}
+
+/** Import by classic asset code + issuer pair (SAC is derived). */
+export interface AssetImportInput {
+  mode: "asset";
+  code: string;
+  issuer: string;
+}
+
+export type TokenImportInput = ContractImportInput | AssetImportInput;
+
+export interface ValidationResult {
+  valid: boolean;
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure validation (no SDK — safe on every render)
+// ---------------------------------------------------------------------------
+
+// StrKey base32 alphabet is RFC 4648 (A–Z, 2–7). Contract ids start with `C`,
+// ed25519 public keys (issuers) with `G`; both encode to 56 chars.
+const CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
+const PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/;
+// Classic asset codes: 1–12 alphanumeric characters.
+const ASSET_CODE_PATTERN = /^[A-Za-z0-9]{1,12}$/;
+
+/** Validates a Soroban contract address (StrKey `C…`) by format. */
+export function validateContractId(value: string): ValidationResult {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { valid: false, error: "Contract address is required." };
+  }
+  if (!CONTRACT_ID_PATTERN.test(trimmed)) {
+    return {
+      valid: false,
+      error: "Enter a valid Stellar contract address (starts with C, 56 characters).",
+    };
+  }
+  return { valid: true, error: null };
+}
+
+/** Validates a classic asset code + issuer pair by format. */
+export function validateAssetInput(
+  code: string,
+  issuer: string,
+): ValidationResult {
+  const trimmedCode = code.trim();
+  const trimmedIssuer = issuer.trim();
+
+  if (!trimmedCode) {
+    return { valid: false, error: "Asset code is required." };
+  }
+  if (!ASSET_CODE_PATTERN.test(trimmedCode)) {
+    return {
+      valid: false,
+      error: "Asset code must be 1–12 alphanumeric characters.",
+    };
+  }
+  if (!trimmedIssuer) {
+    return { valid: false, error: "Issuer address is required." };
+  }
+  if (!PUBLIC_KEY_PATTERN.test(trimmedIssuer)) {
+    return {
+      valid: false,
+      error: "Enter a valid issuer address (starts with G, 56 characters).",
+    };
+  }
+  return { valid: true, error: null };
+}
+
+/** Validates whichever input mode is active. */
+export function validateImportInput(input: TokenImportInput): ValidationResult {
+  return input.mode === "contract"
+    ? validateContractId(input.contractId)
+    : validateAssetInput(input.code, input.issuer);
+}
+
+// ---------------------------------------------------------------------------
+// Local-storage persistence
+// ---------------------------------------------------------------------------
+
+function isCustomTokenArray(value: unknown): value is CustomToken[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as CustomToken).contractId === "string" &&
+        typeof (item as CustomToken).symbol === "string" &&
+        typeof (item as CustomToken).name === "string" &&
+        typeof (item as CustomToken).decimals === "number",
+    )
+  );
+}
+
+/** Returns all imported custom tokens (empty array when none/unavailable). */
+export function getCustomTokens(): CustomToken[] {
+  return getItem<CustomToken[]>(STORAGE_KEY, isCustomTokenArray, []) ?? [];
+}
+
+/** True when a token with the given contract id is already imported. */
+export function isTokenImported(contractId: string): boolean {
+  return getCustomTokens().some((token) => token.contractId === contractId);
+}
+
+/**
+ * Persists a custom token, replacing any existing entry with the same
+ * contract id. Returns the updated token list.
+ */
+export function saveCustomToken(
+  metadata: TokenMetadata,
+): CustomToken[] {
+  const existing = getCustomTokens().filter(
+    (token) => token.contractId !== metadata.contractId,
+  );
+
+  const record: CustomToken = {
+    contractId: metadata.contractId,
+    symbol: metadata.symbol,
+    name: metadata.name,
+    decimals: metadata.decimals,
+    issuer: metadata.issuer,
+    addedAt: Date.now(),
+    verified: false,
+  };
+
+  const next = [...existing, record];
+  setItem(STORAGE_KEY, next);
+  return next;
+}
+
+/** Removes an imported token by contract id. Returns the updated list. */
+export function removeCustomToken(contractId: string): CustomToken[] {
+  const next = getCustomTokens().filter(
+    (token) => token.contractId !== contractId,
+  );
+  setItem(STORAGE_KEY, next);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Network metadata resolution (lazy-loads the Stellar SDK)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves token metadata (name, symbol, decimals) from the network.
+ *
+ * For a raw contract address the token contract is queried directly. For a
+ * classic asset code+issuer pair the deterministic SAC contract id is derived
+ * first, then queried the same way. Each metadata entry is read via a
+ * read-only Soroban `simulateTransaction` — no wallet or funded account is
+ * required, so a throwaway source keypair is used purely to satisfy the
+ * transaction envelope.
+ *
+ * @throws if the input is malformed or the contract does not expose the
+ *         expected SAC/SEP-41 metadata entry points.
+ */
+export async function fetchTokenMetadata(
+  input: TokenImportInput,
+): Promise<TokenMetadata> {
+  const {
+    Account,
+    Asset,
+    Contract,
+    Keypair,
+    Networks,
+    rpc,
+    TransactionBuilder,
+    scValToNative,
+  } = await import("@stellar/stellar-sdk");
+
+  let contractId: string;
+  let issuer: string | undefined;
+
+  if (input.mode === "asset") {
+    const code = input.code.trim();
+    const issuerKey = input.issuer.trim();
+    let asset: InstanceType<typeof Asset>;
+    try {
+      asset = new Asset(code, issuerKey);
+    } catch {
+      throw new Error("Invalid asset code or issuer address.");
+    }
+    contractId = asset.contractId(Networks.TESTNET);
+    issuer = issuerKey;
+  } else {
+    contractId = input.contractId.trim();
+  }
+
+  const server = new rpc.Server(SOROBAN_RPC_URL, { allowHttp: true });
+  const contract = new Contract(contractId);
+  // Throwaway source account — simulation never touches the ledger.
+  const source = new Account(Keypair.random().publicKey(), "0");
+
+  const readEntry = async (method: string): Promise<unknown> => {
+    const tx = new TransactionBuilder(source, {
+      fee: SIMULATION_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(contract.call(method))
+      .setTimeout(30)
+      .build();
+
+    const sim = await server.simulateTransaction(tx);
+    if (rpc.Api.isSimulationError(sim)) {
+      throw new Error(`Contract does not expose "${method}()": ${sim.error}`);
+    }
+    const retval = sim.result?.retval;
+    if (!retval) {
+      throw new Error(`Contract returned no value for "${method}()".`);
+    }
+    return scValToNative(retval);
+  };
+
+  let name: unknown;
+  let symbol: unknown;
+  let decimals: unknown;
+  try {
+    [name, symbol, decimals] = await Promise.all([
+      readEntry("name"),
+      readEntry("symbol"),
+      readEntry("decimals"),
+    ]);
+  } catch (err) {
+    if (err instanceof Error) throw err;
+    throw new Error("Failed to read token metadata from the network.");
+  }
+
+  const parsedDecimals = Number(decimals);
+  if (!Number.isFinite(parsedDecimals)) {
+    throw new Error("Contract returned invalid decimals.");
+  }
+
+  return {
+    contractId,
+    name: String(name),
+    symbol: String(symbol),
+    decimals: parsedDecimals,
+    issuer,
+  };
+}

--- a/src/lib/escrowOps.ts
+++ b/src/lib/escrowOps.ts
@@ -19,7 +19,7 @@ export interface ClaimEscrowResult {
 
 async function waitForTransaction(
   server: InstanceType<
-    Awaited<typeof import('@stellar/stellar-sdk')>['SorobanRpc']['Server']
+    Awaited<typeof import('@stellar/stellar-sdk')>['rpc']['Server']
   >,
   hash: string,
 ): Promise<void> {
@@ -53,7 +53,7 @@ export async function claimEscrow({
   const {
     Contract,
     Networks,
-    SorobanRpc,
+    rpc,
     TransactionBuilder,
     nativeToScVal,
     Transaction,
@@ -68,7 +68,7 @@ export async function claimEscrow({
     throw new Error('Could not retrieve public key from Freighter.');
   }
 
-  const rpcServer = new SorobanRpc.Server(SOROBAN_RPC_URL, { allowHttp: true });
+  const rpcServer = new rpc.Server(SOROBAN_RPC_URL, { allowHttp: true });
   const contract = new Contract(contractId);
   const preimageBytes = Buffer.from(preimageHex, 'hex');
 

--- a/src/lib/transactionOps.ts
+++ b/src/lib/transactionOps.ts
@@ -38,7 +38,7 @@ export async function submitTransaction(payload: Record<string, number>): Promis
   console.log("Preparing transaction with payload:", payload);
 
   const { isConnected, getAddress } = await import("@stellar/freighter-api");
-  const { Keypair, TransactionBuilder, Networks, Transaction } = await import("@stellar/stellar-sdk");
+  const { Horizon, TransactionBuilder, Networks, Transaction } = await import("@stellar/stellar-sdk");
 
   if (!(await isConnected())) {
     throw new Error("Freighter wallet is not connected. Please connect your wallet first.");


### PR DESCRIPTION
# 🏷️ Custom Token Import & Unverified Asset Security Warning Modal

Closes #609

## Summary

Enables users to import custom Stellar asset contracts (SAC / SEP-41) by
entering either a Soroban contract address or an asset code + issuer pair.
Because manually imported tokens are inherently **unverified** (not part of any
curated allow-list), the flow surfaces an explicit security warning that
requires a manual confirmation checkmark before the token can be saved.

This PR also fixes three pre-existing runtime bugs in the Stellar SDK usage
that were uncovered while wiring up on-chain metadata resolution (see
[Stellar fixes](#stellar-sdk-v16-fixes)).

## Acceptance criteria

| Requirement | Status | Where |
| --- | --- | --- |
| Query Horizon / Soroban RPC to fetch token metadata (Name, Symbol, Decimals) | ✅ | `fetchTokenMetadata` in `src/lib/customTokens.ts` |
| Render explicit safety warning dialog requiring manual confirmation checkmark | ✅ | `ImportTokenModal` in `src/components/tokens/ImportTokenModal.tsx` |
| Store user-imported custom tokens in local browser storage | ✅ | `saveCustomToken` / `getCustomTokens` in `src/lib/customTokens.ts` (versioned key `stellarflow.customTokens.v1`) |

## What's included

### Custom token data layer — `src/lib/customTokens.ts`
- Pure, synchronous validation for both import modes (contract id, and asset
  code + issuer), safe to run on every keystroke.
- Local-storage persistence under a versioned key. Every record is flagged
  `verified: false` so the UI never has to re-derive trust.
- On-demand metadata resolution (name, symbol, decimals) against Soroban RPC /
  Horizon. The Stellar SDK is lazy-loaded so it stays out of the initial
  bundle and is only fetched when the user resolves a token.

### Import UI — `src/components/tokens/ImportTokenModal.tsx`
- Two import modes: contract address, or asset code + issuer.
- Fetches and previews resolved metadata before the import is committed.
- Explicit unverified-asset security warning gated behind a manual
  confirmation checkmark — the import button stays disabled until the user
  acknowledges the risk.
- Barrel export added at `src/components/tokens/index.ts`.

### Stellar SDK v16 fixes
`@stellar/stellar-sdk` v16 removed the `SorobanRpc` namespace (replaced by
`rpc`). Three call sites still referenced the removed export or the wrong
import and would throw a `ReferenceError` at runtime:

- **`src/lib/transactionOps.ts`** — `submitTransaction` constructed a
  `Horizon.Server` but destructured `Keypair` (unused) instead of `Horizon`.
  Now imports `Horizon`.
- **`src/lib/escrowOps.ts`** — `SorobanRpc.Server` → `rpc.Server` in
  `claimEscrow` and the `waitForTransaction` type.
- **`src/app/components/providers/NetworkProvider.tsx`** — `SorobanRpc.Server`
  → `rpc.Server` in the SDK module type and `buildClients`.

Verified against the installed SDK: `SorobanRpc` is `undefined`, while
`rpc.Server` and `Horizon.Server` are valid constructors.

## Commits

- `feat(tokens): add custom token import library`
- `feat(tokens): add ImportTokenModal with unverified-asset warning`
- `feat(tokens): export ImportTokenModal from tokens barrel`
- `fix(stellar): import Horizon in submitTransaction to fix ReferenceError`
- `fix(stellar): use rpc namespace in escrowOps for stellar-sdk v16`
- `fix(stellar): construct rpc.Server in NetworkProvider for stellar-sdk v16`

## Testing

- `npm test` (lang-cache suite) — ✅ passes.
- Confirmed no `SorobanRpc` references remain anywhere in `src/`.
- Verified SDK v16 exports at runtime: `rpc.Server` and `Horizon.Server` are
  functions; `SorobanRpc` is `undefined`.


## Related issue

- StellarFlow-Network/stellarflow-frontend#609
