### PR TITLE
feat(remittance): add progress stepper & status tracker (#537)

### DIFF
--- a/src/app/remittance/[txId]/page.tsx
+++ b/src/app/remittance/[txId]/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+/**
+ * RemittanceStatusPage  —  /remittance/[txId]
+ *
+ * Renders the StatusStepper for a single remittance transaction.
+ * All real-time logic lives in the `useRemittanceStatus` hook; this page
+ * is purely presentational integration wiring.
+ *
+ * Usage:
+ *   Navigate to /remittance/<transaction-id>
+ *   e.g. /remittance/abc123ef
+ *
+ * In development / demo mode (no live backend), the page boots with a
+ * mock status object so the stepper is always visible and interactive.
+ */
+
+import React, { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { StatusStepper } from "@/components/remittance/StatusStepper";
+import {
+  useRemittanceStatus,
+  RemittanceStatus,
+  REMITTANCE_STEPS,
+} from "@/hooks/useRemittanceStatus";
+import Icon from "@/components/icons/Icon";
+import { ICON_IDS } from "@/components/icons/iconIds";
+
+// ---------------------------------------------------------------------------
+// Demo / development helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a synthetic mock status for development / UI review.
+ * Cycles through steps every 3 seconds so designers can see all states
+ * without a live backend. Remove / disable when connecting to a real API.
+ */
+function useMockStatus(txId: string): RemittanceStatus {
+  const [stepIdx, setStepIdx] = useState(1); // start at "swap_completed" for interest
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setStepIdx((prev) =>
+        prev < REMITTANCE_STEPS.length - 1 ? prev + 1 : prev,
+      );
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const currentStep = REMITTANCE_STEPS[stepIdx];
+
+  return {
+    txId,
+    currentStep,
+    phase: stepIdx === REMITTANCE_STEPS.length - 1 ? "completed" : "active",
+    stepMeta: {
+      deposited: {
+        step: "deposited",
+        completedAt: new Date(Date.now() - 8 * 60_000).toISOString(),
+        txHash:
+          "3b6a9f4e7d2c1e0f8a5b4c9d3e7f2a1b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f",
+      },
+      swap_completed:
+        stepIdx >= 1
+          ? {
+              step: "swap_completed",
+              completedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+              txHash:
+                "9d1a2b3c4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b",
+            }
+          : undefined,
+      anchor_processing:
+        stepIdx >= 2
+          ? {
+              step: "anchor_processing",
+              completedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+            }
+          : undefined,
+      offramp_dispatched:
+        stepIdx >= 3
+          ? {
+              step: "offramp_dispatched",
+              completedAt: new Date(Date.now() - 30_000).toISOString(),
+            }
+          : undefined,
+      delivered:
+        stepIdx >= 4
+          ? {
+              step: "delivered",
+              completedAt: new Date().toISOString(),
+            }
+          : undefined,
+    },
+    estimatedDeliveryMs: stepIdx < 4 ? Date.now() + 4 * 60_000 : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Decide whether we are in demo mode (no real backend configured).
+// ---------------------------------------------------------------------------
+const IS_DEMO_MODE =
+  typeof process !== "undefined" &&
+  !process.env.NEXT_PUBLIC_API_URL;
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface RemittanceStatusPageProps {
+  params: Promise<{ txId: string }>;
+}
+
+export default function RemittanceStatusPage({
+  params,
+}: RemittanceStatusPageProps) {
+  const { txId } = use(params);
+
+  // Reject obviously invalid IDs early (< 4 chars or > 128 chars)
+  if (!txId || txId.length < 4 || txId.length > 128) {
+    notFound();
+  }
+
+  return IS_DEMO_MODE ? (
+    <DemoPage txId={txId} />
+  ) : (
+    <LivePage txId={txId} />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LivePage — wired to the real useRemittanceStatus hook
+// ---------------------------------------------------------------------------
+
+function LivePage({ txId }: { txId: string }) {
+  const { status, isConnected, isPolling, error, refetch } =
+    useRemittanceStatus(txId, {
+      pollIntervalMs: 5_000,
+      stopOnDelivered: true,
+    });
+
+  return (
+    <PageShell txId={txId}>
+      <StatusStepper
+        status={status}
+        isConnected={isConnected}
+        isPolling={isPolling}
+        error={error}
+        onRefetch={refetch}
+        network={
+          process.env.NEXT_PUBLIC_STELLAR_NETWORK === "testnet"
+            ? "testnet"
+            : "mainnet"
+        }
+      />
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DemoPage — mock status that auto-advances through all five steps
+// ---------------------------------------------------------------------------
+
+function DemoPage({ txId }: { txId: string }) {
+  const mockStatus = useMockStatus(txId);
+
+  return (
+    <PageShell txId={txId}>
+      {/* Demo notice banner */}
+      <div
+        role="note"
+        className="mb-4 flex items-start gap-2 rounded-lg border border-yellow-700/40 bg-yellow-950/20 px-3 py-2.5 text-xs text-yellow-400"
+      >
+        <Icon
+          id={ICON_IDS.alertTriangle}
+          size={13}
+          className="mt-0.5 flex-shrink-0"
+        />
+        <span>
+          <strong>Demo mode</strong> — NEXT_PUBLIC_API_URL is not set. Status
+          auto-advances every 3 s using mock data. Steps cycle through all five
+          states for UI preview.
+        </span>
+      </div>
+
+      <StatusStepper
+        status={mockStatus}
+        isConnected={false}
+        isPolling={false}
+        network="testnet"
+      />
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared page shell
+// ---------------------------------------------------------------------------
+
+function PageShell({
+  txId,
+  children,
+}: {
+  txId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen bg-[#080d12] px-4 py-8 md:px-8 lg:px-12">
+      {/* Breadcrumb nav */}
+      <nav
+        aria-label="Breadcrumb"
+        className="mb-6 flex items-center gap-2 text-xs text-gray-600"
+      >
+        <Link
+          href="/"
+          className="transition-colors hover:text-gray-400"
+        >
+          Home
+        </Link>
+        <Icon
+          id={ICON_IDS.chevronRight}
+          size={12}
+          className="text-gray-700"
+        />
+        <span className="text-gray-500">Remittance</span>
+        <Icon
+          id={ICON_IDS.chevronRight}
+          size={12}
+          className="text-gray-700"
+        />
+        <span
+          className="font-mono text-gray-400 truncate max-w-[12rem]"
+          title={txId}
+        >
+          {txId}
+        </span>
+      </nav>
+
+      {/* Page heading */}
+      <div className="mb-6">
+        <h1 className="flex items-center gap-2 text-xl font-bold text-gray-100">
+          <Icon
+            id={ICON_IDS.activity}
+            size={20}
+            className="text-blue-400"
+          />
+          Remittance Tracker
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Real-time progress across five stages from deposit to delivery.
+        </p>
+      </div>
+
+      {/* Stepper card — constrained width for readability */}
+      <div className="mx-auto max-w-lg">{children}</div>
+
+      {/* Footer links */}
+      <div className="mx-auto mt-8 max-w-lg">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-gray-700">
+          <a
+            href="https://stellar.expert/explorer/public"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 transition-colors hover:text-gray-400"
+          >
+            <Icon id={ICON_IDS.externalLink} size={11} />
+            Stellar Expert Explorer
+          </a>
+          <span aria-hidden>·</span>
+          <Link href="/" className="transition-colors hover:text-gray-400">
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/remittance/StatusStepper.tsx
+++ b/src/components/remittance/StatusStepper.tsx
@@ -1,0 +1,568 @@
+"use client";
+
+import React, { useMemo } from "react";
+import Icon from "@/components/icons/Icon";
+import { ICON_IDS } from "@/components/icons/iconIds";
+import {
+  REMITTANCE_STEPS,
+  RemittanceStatus,
+  RemittanceStep,
+  isStepActive,
+  isStepCompleted,
+  stepIndex,
+  stellarExpertTxUrl,
+} from "@/hooks/useRemittanceStatus";
+
+// ---------------------------------------------------------------------------
+// Step display metadata
+// ---------------------------------------------------------------------------
+
+interface StepDisplayMeta {
+  label: string;
+  description: string;
+  iconId: (typeof ICON_IDS)[keyof typeof ICON_IDS];
+}
+
+const STEP_DISPLAY: Record<RemittanceStep, StepDisplayMeta> = {
+  deposited: {
+    label: "Deposited",
+    description: "Funds received and confirmed on-chain.",
+    iconId: ICON_IDS.wallet,
+  },
+  swap_completed: {
+    label: "Swap Completed",
+    description: "XLM ↔ local currency swap executed.",
+    iconId: ICON_IDS.zap,
+  },
+  anchor_processing: {
+    label: "Anchor Processing",
+    description: "Licensed anchor validating the off-ramp request.",
+    iconId: ICON_IDS.shield,
+  },
+  offramp_dispatched: {
+    label: "Off-Ramp Dispatched",
+    description: "Payment instruction sent to local payout rail.",
+    iconId: ICON_IDS.upload,
+  },
+  delivered: {
+    label: "Delivered",
+    description: "Funds landed in the recipient's account.",
+    iconId: ICON_IDS.checkCircle,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-component: individual step node
+// ---------------------------------------------------------------------------
+
+interface StepNodeProps {
+  step: RemittanceStep;
+  completed: boolean;
+  active: boolean;
+  failed: boolean;
+  txHash?: string;
+  completedAt?: string;
+  network?: "mainnet" | "testnet";
+  isLast: boolean;
+}
+
+const StepNode = React.memo(function StepNode({
+  step,
+  completed,
+  active,
+  failed,
+  txHash,
+  completedAt,
+  network = "mainnet",
+  isLast,
+}: StepNodeProps) {
+  const meta = STEP_DISPLAY[step];
+
+  // Circle state styles
+  const circleBase =
+    "relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all duration-500";
+
+  const circleClass = failed
+    ? `${circleBase} border-red-500 bg-red-950/40`
+    : completed
+      ? `${circleBase} border-emerald-500 bg-emerald-950/50 shadow-[0_0_10px_2px_rgba(52,211,153,0.25)]`
+      : active
+        ? `${circleBase} border-blue-400 bg-blue-950/50 shadow-[0_0_12px_3px_rgba(96,165,250,0.3)] ring-2 ring-blue-500/20 ring-offset-2 ring-offset-[#0d1117]`
+        : `${circleBase} border-gray-700 bg-gray-900`;
+
+  const iconColor = failed
+    ? "text-red-400"
+    : completed
+      ? "text-emerald-400"
+      : active
+        ? "text-blue-400"
+        : "text-gray-600";
+
+  const labelColor = failed
+    ? "text-red-300"
+    : completed
+      ? "text-emerald-300"
+      : active
+        ? "text-blue-300 font-semibold"
+        : "text-gray-500";
+
+  const descColor = failed
+    ? "text-red-400/70"
+    : completed
+      ? "text-gray-400"
+      : active
+        ? "text-gray-300"
+        : "text-gray-600";
+
+  const formattedDate = completedAt
+    ? new Date(completedAt).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+
+  return (
+    <li className="relative flex gap-4">
+      {/* Vertical connector line — hidden for the last item */}
+      {!isLast && (
+        <div
+          aria-hidden
+          className={`absolute left-[19px] top-10 h-full w-0.5 transition-colors duration-500 ${
+            completed ? "bg-emerald-700/60" : "bg-gray-800"
+          }`}
+        />
+      )}
+
+      {/* Step icon node */}
+      <div className={circleClass} aria-hidden>
+        {completed ? (
+          <Icon
+            id={ICON_IDS.check}
+            size={18}
+            className={iconColor}
+            strokeWidth={2.5}
+          />
+        ) : failed ? (
+          <Icon
+            id={ICON_IDS.alertTriangle}
+            size={18}
+            className={iconColor}
+          />
+        ) : active ? (
+          /* Pulsing ring for the active step */
+          <>
+            <Icon id={meta.iconId} size={18} className={iconColor} />
+            <span
+              className="absolute inset-0 rounded-full animate-ping opacity-30 bg-blue-400"
+              aria-hidden
+            />
+          </>
+        ) : (
+          <Icon id={meta.iconId} size={18} className={iconColor} />
+        )}
+      </div>
+
+      {/* Step text content */}
+      <div className="min-w-0 flex-1 pb-8">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          <span className={`text-sm transition-colors duration-300 ${labelColor}`}>
+            {meta.label}
+          </span>
+
+          {active && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/30 bg-blue-950/30 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-blue-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse" aria-hidden />
+              In Progress
+            </span>
+          )}
+
+          {completed && (
+            <span className="rounded-full border border-emerald-800/40 bg-emerald-950/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-600">
+              Done
+            </span>
+          )}
+        </div>
+
+        <p className={`mt-0.5 text-xs leading-relaxed ${descColor}`}>
+          {meta.description}
+        </p>
+
+        {/* Completion timestamp */}
+        {formattedDate && (
+          <p className="mt-1 text-[11px] font-mono text-gray-600">
+            <Icon
+              id={ICON_IDS.clock}
+              size={11}
+              className="mr-1 inline-block align-middle text-gray-700"
+            />
+            {formattedDate}
+          </p>
+        )}
+
+        {/* Stellar Expert block explorer link */}
+        {txHash && (
+          <a
+            href={stellarExpertTxUrl(txHash, network)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1.5 inline-flex items-center gap-1 text-[11px] font-mono text-blue-500 hover:text-blue-400 underline-offset-2 hover:underline transition-colors"
+            aria-label={`View transaction ${txHash.slice(0, 8)}… on Stellar Expert`}
+          >
+            <Icon id={ICON_IDS.externalLink} size={11} className="flex-shrink-0" />
+            {txHash.slice(0, 8)}…{txHash.slice(-8)}
+          </a>
+        )}
+      </div>
+    </li>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Progress bar sub-component
+// ---------------------------------------------------------------------------
+
+interface ProgressBarProps {
+  currentStep: RemittanceStep | null;
+  failed: boolean;
+}
+
+const ProgressBar = React.memo(function ProgressBar({
+  currentStep,
+  failed,
+}: ProgressBarProps) {
+  const totalSteps = REMITTANCE_STEPS.length;
+  const idx = stepIndex(currentStep);
+  // Progress completes fully at the last step.
+  const pct = failed
+    ? 100
+    : idx < 0
+      ? 0
+      : Math.round(((idx + 1) / totalSteps) * 100);
+
+  const barColor = failed
+    ? "bg-gradient-to-r from-red-700 to-red-500"
+    : pct === 100
+      ? "bg-gradient-to-r from-emerald-700 to-emerald-400"
+      : "bg-gradient-to-r from-blue-700 to-blue-400";
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-medium uppercase tracking-wider text-gray-500">
+          Progress
+        </span>
+        <span
+          className={`text-xs font-mono font-semibold tabular-nums ${
+            failed
+              ? "text-red-400"
+              : pct === 100
+                ? "text-emerald-400"
+                : "text-blue-400"
+          }`}
+          aria-live="polite"
+          aria-atomic
+        >
+          {pct}%
+        </span>
+      </div>
+
+      {/* Track */}
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Remittance progress"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-gray-800"
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-700 ease-out ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Step count label */}
+      <p className="mt-1.5 text-[11px] text-gray-600 font-mono">
+        Step{" "}
+        {idx < 0 ? "—" : `${idx + 1} / ${totalSteps}`}
+        {currentStep && (
+          <> · {STEP_DISPLAY[currentStep].label}</>
+        )}
+      </p>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Connection indicator sub-component
+// ---------------------------------------------------------------------------
+
+interface ConnectionBadgeProps {
+  isConnected: boolean;
+  isPolling: boolean;
+}
+
+const ConnectionBadge = React.memo(function ConnectionBadge({
+  isConnected,
+  isPolling,
+}: ConnectionBadgeProps) {
+  if (!isConnected && !isPolling) return null;
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${
+        isConnected
+          ? "border-emerald-800/40 bg-emerald-950/20 text-emerald-500"
+          : "border-gray-700/60 bg-gray-900/40 text-gray-500"
+      }`}
+      aria-label={isConnected ? "Live via WebSocket" : "Polling for updates"}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          isConnected ? "bg-emerald-400 animate-pulse" : "bg-gray-500"
+        }`}
+        aria-hidden
+      />
+      {isConnected ? "Live" : "Polling"}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main StatusStepper component
+// ---------------------------------------------------------------------------
+
+export interface StatusStepperProps {
+  /** Live status object from `useRemittanceStatus`. */
+  status: RemittanceStatus | null;
+  /** Whether the WebSocket channel is currently open. */
+  isConnected?: boolean;
+  /** Whether the hook is currently HTTP-polling. */
+  isPolling?: boolean;
+  /** Error string from the hook, if any. */
+  error?: string | null;
+  /** Callback for the retry / refetch button. */
+  onRefetch?: () => void;
+  /** "mainnet" or "testnet" — controls the Stellar Expert URL. Default: mainnet. */
+  network?: "mainnet" | "testnet";
+  /** Additional class names for the outer container. */
+  className?: string;
+}
+
+/**
+ * `StatusStepper` — a vertical progress stepper that visualises a remittance
+ * transaction moving through five states:
+ *
+ *   Deposited → Swap Completed → Anchor Processing → Off-Ramp Dispatched → Delivered
+ *
+ * Features:
+ * - Animated progress bar showing the percentage of steps completed
+ * - Per-step icons, labels, and descriptions
+ * - Pulsing active-step indicator
+ * - Inline timestamps for completed steps
+ * - Direct links to Stellar Expert block explorer for verified on-chain steps
+ * - Live / Polling connection badge
+ * - Error and loading states
+ * - Fully accessible (ARIA roles, live regions, keyboard-reachable links)
+ */
+export const StatusStepper = React.memo(function StatusStepper({
+  status,
+  isConnected = false,
+  isPolling = false,
+  error = null,
+  onRefetch,
+  network = "mainnet",
+  className = "",
+}: StatusStepperProps) {
+  const { currentStep, phase, stepMeta } = status ?? {
+    currentStep: null,
+    phase: "idle" as const,
+    stepMeta: {},
+  };
+
+  const isFailed = phase === "failed";
+  const isDelivered = currentStep === "delivered" && phase === "completed";
+
+  // Build a stable list of step props for rendering — avoids per-render object churn.
+  const steps = useMemo(
+    () =>
+      REMITTANCE_STEPS.map((step, i) => ({
+        step,
+        completed: isStepCompleted(step, currentStep),
+        active: isStepActive(step, currentStep),
+        failed: isFailed && isStepActive(step, currentStep),
+        txHash: stepMeta[step]?.txHash,
+        completedAt: stepMeta[step]?.completedAt,
+        isLast: i === REMITTANCE_STEPS.length - 1,
+      })),
+    [currentStep, isFailed, stepMeta],
+  );
+
+  return (
+    <section
+      aria-label="Remittance progress tracker"
+      className={`w-full rounded-2xl border border-gray-800 bg-[#0d1117] p-5 shadow-xl ${className}`}
+    >
+      {/* Header row */}
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wider text-gray-200">
+            <Icon id={ICON_IDS.activity} size={15} className="text-blue-400" />
+            Transfer Status
+          </h2>
+          {status?.txId && (
+            <p className="mt-0.5 font-mono text-[11px] text-gray-600">
+              ID: {status.txId.slice(0, 10)}…{status.txId.slice(-10)}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <ConnectionBadge isConnected={isConnected} isPolling={isPolling} />
+
+          {onRefetch && !isDelivered && (
+            <button
+              type="button"
+              onClick={onRefetch}
+              aria-label="Refresh transfer status"
+              className="rounded-lg border border-gray-700 p-1.5 text-gray-400 transition-colors hover:border-gray-600 hover:bg-gray-800 hover:text-gray-200"
+            >
+              <Icon id={ICON_IDS.refresh} size={13} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      {phase !== "idle" && (
+        <ProgressBar currentStep={currentStep} failed={isFailed} />
+      )}
+
+      {/* Loading skeleton */}
+      {(phase === "loading" || phase === "idle") && !error && (
+        <div className="space-y-5" aria-busy aria-label="Loading transfer status">
+          {REMITTANCE_STEPS.map((step) => (
+            <div key={step} className="flex gap-4">
+              <div className="h-10 w-10 flex-shrink-0 animate-pulse rounded-full bg-gray-800" />
+              <div className="flex-1 space-y-2 pt-1">
+                <div className="h-3 w-24 animate-pulse rounded bg-gray-800" />
+                <div className="h-2.5 w-40 animate-pulse rounded bg-gray-800/60" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-950/20 p-3 text-sm text-red-300"
+        >
+          <Icon
+            id={ICON_IDS.alertTriangle}
+            size={15}
+            className="mt-0.5 flex-shrink-0 text-red-400"
+          />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium">Unable to load status</p>
+            <p className="mt-0.5 text-xs text-red-400/80">{error}</p>
+          </div>
+          {onRefetch && (
+            <button
+              type="button"
+              onClick={onRefetch}
+              className="flex-shrink-0 rounded border border-red-700/40 bg-red-950/40 px-2 py-1 text-xs text-red-300 hover:bg-red-900/40 transition-colors"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Step list */}
+      {phase !== "idle" && phase !== "loading" && (
+        <ol
+          aria-label="Remittance steps"
+          className="space-y-0"
+        >
+          {steps.map(({ step, completed, active, failed, txHash, completedAt, isLast }) => (
+            <StepNode
+              key={step}
+              step={step}
+              completed={completed}
+              active={active}
+              failed={failed}
+              txHash={txHash}
+              completedAt={completedAt}
+              network={network}
+              isLast={isLast}
+            />
+          ))}
+        </ol>
+      )}
+
+      {/* Delivered celebration banner */}
+      {isDelivered && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mt-4 flex items-center gap-3 rounded-xl border border-emerald-700/40 bg-emerald-950/20 px-4 py-3"
+        >
+          <Icon
+            id={ICON_IDS.checkCircle}
+            size={20}
+            className="flex-shrink-0 text-emerald-400"
+          />
+          <div>
+            <p className="text-sm font-semibold text-emerald-300">
+              Transfer Delivered
+            </p>
+            <p className="text-xs text-emerald-700 mt-0.5">
+              Funds have arrived in the recipient&apos;s account.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Failed banner */}
+      {isFailed && status?.errorMessage && (
+        <div
+          role="alert"
+          className="mt-4 flex items-start gap-3 rounded-xl border border-red-700/40 bg-red-950/20 px-4 py-3"
+        >
+          <Icon
+            id={ICON_IDS.alertTriangle}
+            size={18}
+            className="flex-shrink-0 mt-0.5 text-red-400"
+          />
+          <div>
+            <p className="text-sm font-semibold text-red-300">Transfer Failed</p>
+            <p className="text-xs text-red-400/80 mt-0.5">{status.errorMessage}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Estimated delivery */}
+      {status?.estimatedDeliveryMs && !isDelivered && !isFailed && (
+        <div className="mt-5 flex items-center gap-1.5 border-t border-gray-800/60 pt-3 text-xs text-gray-600">
+          <Icon id={ICON_IDS.clock} size={12} className="text-gray-700" />
+          Estimated delivery:{" "}
+          <span className="font-mono text-gray-500">
+            {new Date(status.estimatedDeliveryMs).toLocaleString(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </span>
+        </div>
+      )}
+    </section>
+  );
+});
+
+StatusStepper.displayName = "StatusStepper";
+export default StatusStepper;

--- a/src/hooks/useRemittanceStatus.ts
+++ b/src/hooks/useRemittanceStatus.ts
@@ -1,0 +1,365 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRAFInterval } from "@/app/hooks/useRAFInterval";
+import { usePageVisibility } from "@/app/hooks/usePageVisibility";
+import { useErrorTimeout } from "@/app/hooks/useErrorTimeout";
+
+// ---------------------------------------------------------------------------
+// Remittance status domain types
+// ---------------------------------------------------------------------------
+
+/**
+ * The five ordered states a remittance travels through.
+ * The numeric order is intentional — comparison helpers rely on it.
+ */
+export type RemittanceStep =
+  | "deposited"
+  | "swap_completed"
+  | "anchor_processing"
+  | "offramp_dispatched"
+  | "delivered";
+
+export const REMITTANCE_STEPS: RemittanceStep[] = [
+  "deposited",
+  "swap_completed",
+  "anchor_processing",
+  "offramp_dispatched",
+  "delivered",
+];
+
+/**
+ * Metadata returned for each completed or in-progress step.
+ * `txHash` is present only for on-chain steps that have a verified transaction.
+ */
+export interface RemittanceStepMeta {
+  step: RemittanceStep;
+  completedAt?: string; // ISO 8601
+  txHash?: string;      // Stellar transaction hash for block explorer link
+}
+
+export type RemittanceStatusPhase =
+  | "idle"
+  | "loading"
+  | "active"
+  | "completed"
+  | "failed";
+
+export interface RemittanceStatus {
+  txId: string;
+  currentStep: RemittanceStep | null;
+  stepMeta: Partial<Record<RemittanceStep, RemittanceStepMeta>>;
+  phase: RemittanceStatusPhase;
+  estimatedDeliveryMs?: number; // Unix timestamp
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook options and return shape
+// ---------------------------------------------------------------------------
+
+export interface UseRemittanceStatusOptions {
+  /** How often (ms) to poll when WebSocket is unavailable. Default: 5 000 ms */
+  pollIntervalMs?: number;
+  /** Maximum polling attempts before giving up. Default: 60 */
+  maxPollAttempts?: number;
+  /** Disable polling entirely and rely on WebSocket-only. Default: false */
+  wsOnly?: boolean;
+  /** Stop all activity once the remittance reaches the `delivered` state. */
+  stopOnDelivered?: boolean;
+}
+
+export interface UseRemittanceStatusReturn {
+  status: RemittanceStatus | null;
+  isConnected: boolean;
+  isPolling: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const WS_MSG_TYPE = "remittance_status";
+
+/**
+ * Derive a sensible API base URL from the environment.
+ * Falls back to a relative path so the hook works with Next.js API routes
+ * during development even when NEXT_PUBLIC_API_URL is unset.
+ */
+function getApiBase(): string {
+  if (typeof window === "undefined") return "";
+  const envUrl =
+    typeof process !== "undefined"
+      ? (process.env.NEXT_PUBLIC_API_URL ?? "")
+      : "";
+  return envUrl || "";
+}
+
+/**
+ * Build the polling URL for a given transaction ID.
+ */
+function buildPollUrl(txId: string): string {
+  return `${getApiBase()}/api/remittance/${encodeURIComponent(txId)}/status`;
+}
+
+/**
+ * Build the WebSocket URL for remittance status updates.
+ */
+function buildWsUrl(): string {
+  if (typeof window === "undefined") return "";
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const envUrl =
+    typeof process !== "undefined"
+      ? (process.env.NEXT_PUBLIC_API_URL ?? "")
+      : "";
+
+  if (envUrl) {
+    // Strip http(s):// prefix and add ws(s):// so it works for all origins.
+    const stripped = envUrl.replace(/^https?:\/\//, "");
+    return `${protocol}//${stripped}/ws/remittance`;
+  }
+
+  return `${protocol}//${window.location.host}/ws/remittance`;
+}
+
+// ---------------------------------------------------------------------------
+// Hook implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * `useRemittanceStatus` — real-time remittance progress tracking.
+ *
+ * Strategy:
+ * 1. Open a dedicated WebSocket channel `ws(s)://.../ws/remittance` and
+ *    subscribe to updates for the given `txId`.
+ * 2. On connect, send `{ type: "subscribe", txId }`.
+ * 3. On any incoming message of type `remittance_status`, update state.
+ * 4. If the WebSocket fails to connect or is unavailable (e.g., server-side
+ *    render, non-WS environment), fall back to HTTP polling via
+ *    `GET /api/remittance/:txId/status`.
+ * 5. Polling stops once `delivered` is reached (when `stopOnDelivered` is true)
+ *    or after `maxPollAttempts` attempts.
+ * 6. All side effects are cleaned up on unmount — no leaks, no ghost timers.
+ */
+export function useRemittanceStatus(
+  txId: string | null,
+  options: UseRemittanceStatusOptions = {},
+): UseRemittanceStatusReturn {
+  const {
+    pollIntervalMs = 5_000,
+    maxPollAttempts = 60,
+    wsOnly = false,
+    stopOnDelivered = true,
+  } = options;
+
+  const [status, setStatus] = useState<RemittanceStatus | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isPolling, setIsPolling] = useState(false);
+  const { error, setError } = useErrorTimeout({ timeoutMs: 0 }); // manual clear
+
+  // Track whether WS is functional so we can decide if polling is needed.
+  const wsHealthyRef = useRef(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const pollCountRef = useRef(0);
+  const isMountedRef = useRef(true);
+  const isVisible = usePageVisibility();
+
+  // Memoised flag: should we stop?
+  const isTerminal =
+    status?.phase === "completed" ||
+    status?.phase === "failed" ||
+    (stopOnDelivered && status?.currentStep === "delivered");
+
+  // ------------------------------------------------------------------
+  // applyUpdate — merge an incoming payload into state
+  // ------------------------------------------------------------------
+  const applyUpdate = useCallback((payload: RemittanceStatus) => {
+    if (!isMountedRef.current) return;
+    setStatus(payload);
+    setError(null);
+  }, [setError]);
+
+  // ------------------------------------------------------------------
+  // HTTP polling
+  // ------------------------------------------------------------------
+  const doPoll = useCallback(async () => {
+    if (!txId || wsHealthyRef.current || isTerminal) return;
+    if (pollCountRef.current >= maxPollAttempts) {
+      setIsPolling(false);
+      setError(`Status check timed out after ${maxPollAttempts} attempts.`);
+      return;
+    }
+
+    try {
+      pollCountRef.current += 1;
+      const res = await fetch(buildPollUrl(txId), {
+        headers: { Accept: "application/json" },
+        // Use no-store to always get a fresh response from the server.
+        cache: "no-store",
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+
+      const data = (await res.json()) as RemittanceStatus;
+      applyUpdate(data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to fetch status";
+      setError(msg);
+    }
+  }, [txId, isTerminal, maxPollAttempts, applyUpdate, setError]);
+
+  // The RAF interval drives polling while visible and WS is unhealthy.
+  const shouldPoll = Boolean(
+    txId && !wsOnly && !wsHealthyRef.current && !isTerminal && isVisible,
+  );
+
+  // Expose polling state reactively.
+  useEffect(() => {
+    setIsPolling(shouldPoll);
+  }, [shouldPoll]);
+
+  useRAFInterval(doPoll, pollIntervalMs, shouldPoll);
+
+  // ------------------------------------------------------------------
+  // WebSocket subscription
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    if (!txId || typeof window === "undefined") return;
+
+    isMountedRef.current = true;
+    pollCountRef.current = 0;
+
+    // Trigger an immediate poll before WS is ready to show a status quickly.
+    if (!wsOnly) {
+      doPoll();
+    }
+
+    const wsUrl = buildWsUrl();
+    let ws: WebSocket;
+
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      // WebSocket construction can throw in some environments — fall back to
+      // polling gracefully.
+      wsHealthyRef.current = false;
+      return;
+    }
+
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (!isMountedRef.current) return;
+      wsHealthyRef.current = true;
+      setIsConnected(true);
+      setError(null);
+
+      // Subscribe to this specific transaction.
+      ws.send(JSON.stringify({ type: "subscribe", txId }));
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      if (!isMountedRef.current) return;
+      try {
+        const msg = JSON.parse(event.data as string) as {
+          type: string;
+          txId?: string;
+          data?: RemittanceStatus;
+        };
+
+        // Guard: only handle messages for our transaction.
+        if (msg.type === WS_MSG_TYPE && msg.txId === txId && msg.data) {
+          applyUpdate(msg.data);
+        }
+      } catch {
+        // Silently discard malformed frames.
+      }
+    };
+
+    ws.onclose = () => {
+      if (!isMountedRef.current) return;
+      wsHealthyRef.current = false;
+      setIsConnected(false);
+      // If the connection closed before delivery, keep polling.
+    };
+
+    ws.onerror = () => {
+      wsHealthyRef.current = false;
+      setIsConnected(false);
+    };
+
+    return () => {
+      isMountedRef.current = false;
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+      }
+      wsRef.current = null;
+    };
+  }, [txId, wsOnly, doPoll, applyUpdate, setError]);
+
+  // ------------------------------------------------------------------
+  // Manual refetch — useful for a "retry" button in the UI.
+  // ------------------------------------------------------------------
+  const refetch = useCallback(async () => {
+    setError(null);
+    pollCountRef.current = 0;
+    await doPoll();
+  }, [doPoll, setError]);
+
+  return { status, isConnected, isPolling, error, refetch };
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers — exported for use in the component layer
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the zero-based index of a step in REMITTANCE_STEPS.
+ * Returns -1 if the step is not found.
+ */
+export function stepIndex(step: RemittanceStep | null | undefined): number {
+  if (!step) return -1;
+  return REMITTANCE_STEPS.indexOf(step);
+}
+
+/**
+ * Returns true when the given step has been completed, given the current step.
+ */
+export function isStepCompleted(
+  step: RemittanceStep,
+  currentStep: RemittanceStep | null,
+): boolean {
+  if (!currentStep) return false;
+  return stepIndex(step) < stepIndex(currentStep);
+}
+
+/**
+ * Returns true when the given step is the currently active (in-progress) step.
+ */
+export function isStepActive(
+  step: RemittanceStep,
+  currentStep: RemittanceStep | null,
+): boolean {
+  return step === currentStep;
+}
+
+/**
+ * Build a Stellar Expert block explorer URL for a given transaction hash.
+ * Defaults to mainnet; pass `"testnet"` for the test network.
+ */
+export function stellarExpertTxUrl(
+  txHash: string,
+  network: "mainnet" | "testnet" = "mainnet",
+): string {
+  const base = "https://stellar.expert/explorer";
+  const net = network === "testnet" ? "testnet" : "public";
+  return `${base}/${net}/tx/${txHash}`;
+}


### PR DESCRIPTION
  **Title:** `feat(remittance): Order-Tracking | Remittance Progress Stepper & Status Tracker (#537)`
  
  ---
  
  ### Summary
  
  Implements real-time remittance order tracking across five execution states, closing issue **#537**. Users can now navigate to `/remittance/[txId]` and watch their transfer progress from
  on-chain deposit through to final fiat delivery — with live status updates, verified on-chain transaction links, and full graceful degradation when a WebSocket is unavailable.
  
  ---
  
  ### Changes
  
  | File | Type | Lines |
  |---|---|---|
  | `src/hooks/useRemittanceStatus.ts` | New | +365 |
  | `src/components/remittance/StatusStepper.tsx` | New | +568 |
  | `src/app/remittance/[txId]/page.tsx` | New | +277 |
  
  **3 files changed · 1,210 insertions · 0 deletions**
  
  ---
  
  ### Technical Detail
  
  **`useRemittanceStatus` hook**
  
  - Opens a dedicated `wss://.../ws/remittance` channel and sends `{ type: "subscribe", txId }` on connect
  - On WS failure, transparently falls back to HTTP polling against `GET /api/remittance/:txId/status`
  - Polling is driven by the existing `useRAFInterval` scheduler — pauses automatically when the browser tab is hidden (`usePageVisibility`), preventing unnecessary backend load on mobile
  - Poll timeout cap of 60 attempts; stops entirely once `delivered` is reached
  - Full cleanup on unmount: WS listeners detached, `isMountedRef` guard prevents stale `setState` after navigation
  - Exports pure utility helpers (`stepIndex`, `isStepCompleted`, `isStepActive`, `stellarExpertTxUrl`) consumed by the component layer
  
  **`StatusStepper` component** (`src/components/remittance/StatusStepper.tsx`)
  
  Tracks the five remittance states in order:
  
  Deposited → Swap Completed → Anchor Processing → Off-Ramp Dispatched → Delivered
  
  - Animated progress bar filling 0→100% across steps; gradient shifts green at completion, red on failure; `role="progressbar"` with `aria-valuenow` for screen readers
  - Per-step connector line turns green as steps are completed
  - Active step renders a pulsing ring animation and "In Progress" badge; completed steps show a checkmark, "Done" badge, and ISO timestamp
  - Where a `txHash` is available, the step renders a direct link to **Stellar Expert** (`https://stellar.expert/explorer/{public|testnet}/tx/{hash}`), opening in a new tab with `rel="noopener
  noreferrer"`
  - Live/Polling connection badge reflects transport state in real time
  - Loading skeleton, error + retry banner, delivered celebration banner, and failed error banner with message passthrough
  - Estimated delivery timestamp footer
  - All sub-components wrapped in `React.memo`; uses the project's existing SVG sprite `Icon` system — no new icon dependencies introduced
  
  **`/remittance/[txId]/page.tsx`**
  
  - Validates `txId` length (4–128 chars) and calls `notFound()` for invalid routes
  - **Demo mode** (when `NEXT_PUBLIC_API_URL` is unset): `useMockStatus` auto-advances through all five steps every 3 s with realistic fake transaction hashes — usable immediately without a
  backend
  - **Live mode**: wires `useRemittanceStatus` → `StatusStepper`; network (`mainnet`/`testnet`) is read from `NEXT_PUBLIC_STELLAR_NETWORK`
  - Breadcrumb navigation and footer link to the Stellar Expert public explorer
  
  ---
  
  ### Checklist
  
  - [x] Satisfies all three technical requirements from issue #537 (real-time WebSocket/polling, visual progress bar, Stellar Expert links)
  - [x] All five remittance states implemented and mapped to descriptive labels
  - [x] No new runtime dependencies introduced — reuses `useRAFInterval`, `usePageVisibility`, `useErrorTimeout`, `Icon`, and the existing SVG sprite
  - [x] Fully accessible — ARIA roles (`progressbar`, `alert`, `status`, `note`), `aria-live` regions, keyboard-reachable external links
  - [x] Demo mode works without a live backend for immediate UI review
  - [x] Committed on `feature/537-remittance-progress-stepper` (`7864bee`)
  
  ---
  
Closes #537

  ### How to Test
  
  ```bash
  # Start the dev server
  npm run dev
  
  # Demo mode (no backend needed) — open:
  http://localhost:3000/remittance/test-transaction-abc123
  
  # Live mode — set env and point at a running backend:
  NEXT_PUBLIC_API_URL=http://localhost:4000
  NEXT_PUBLIC_STELLAR_NETWORK=testnet
  
  In demo mode the stepper auto-advances through all five steps every 3 seconds.
  In live mode it subscribes to the WebSocket channel and falls back to polling automatically if the socket is unavailable.





