### PR TITLE
feat: implement MockWalletProvider and mock transaction capabilities for UI testing

### DIFF
--- a/src/app/components/providers/MockWalletProvider.tsx
+++ b/src/app/components/providers/MockWalletProvider.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  WalletStateContext,
+  WalletStatusContext,
+  WalletActionsContext,
+  type WalletState,
+} from './WalletProvider';
+
+export interface MockWalletConfig {
+  initialConnected?: boolean;
+  publicKey?: string;
+  transactionDelayMs?: number;
+  simulateFailure?: boolean;
+  mockBalances?: Record<string, string>;
+}
+
+interface MockWalletProviderProps {
+  children: React.ReactNode;
+  config?: MockWalletConfig;
+}
+
+const DEFAULT_CONFIG: MockWalletConfig = {
+  initialConnected: true,
+  publicKey: 'GBMOCKXLMPROVIDER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  transactionDelayMs: 1500,
+  simulateFailure: false,
+  mockBalances: {
+    XLM: '10000.00',
+    USDC: '500.00',
+  },
+};
+
+/**
+ * MockWalletProvider
+ * 
+ * Provides a mock wallet environment simulating transactions locally without requiring 
+ * live Stellar testnet connections during design iterations.
+ * Can be used in Storybook or local development.
+ */
+export function MockWalletProvider({ children, config = {} }: MockWalletProviderProps) {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+  const [connected, setConnected] = useState(!!mergedConfig.initialConnected);
+  const [isChecking, setIsChecking] = useState(false);
+  
+  const walletState: WalletState | null = useMemo(() => {
+    if (!connected) return { publicKey: null, connected: false, source: 'none', lastCheckedAt: Date.now() };
+    return {
+      publicKey: mergedConfig.publicKey || null,
+      connected: true,
+      source: 'extension',
+      lastCheckedAt: Date.now(),
+    };
+  }, [connected, mergedConfig.publicKey]);
+
+  const refreshWalletState = React.useCallback(async () => {
+    setIsChecking(true);
+    await new Promise(resolve => setTimeout(resolve, 500));
+    setIsChecking(false);
+    return walletState;
+  }, [walletState]);
+
+  // Export mock transaction functions globally for UI components that use transactionOps
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      (window as any).__MOCK_TX_CONFIG__ = {
+        delayMs: mergedConfig.transactionDelayMs,
+        simulateFailure: mergedConfig.simulateFailure,
+        mockBalances: mergedConfig.mockBalances,
+      };
+    }
+  }, [mergedConfig]);
+
+  const stateValue = useMemo(() => ({ wallet: walletState }), [walletState]);
+  const statusValue = useMemo(() => ({ isChecking, error: null }), [isChecking]);
+  const actionsValue = useMemo(() => ({ refreshWalletState }), [refreshWalletState]);
+
+  return (
+    <WalletStateContext.Provider value={stateValue}>
+      <WalletStatusContext.Provider value={statusValue}>
+        <WalletActionsContext.Provider value={actionsValue}>
+          {children}
+        </WalletActionsContext.Provider>
+      </WalletStatusContext.Provider>
+    </WalletStateContext.Provider>
+  );
+}

--- a/src/app/components/providers/WalletProvider.tsx
+++ b/src/app/components/providers/WalletProvider.tsx
@@ -44,9 +44,9 @@ interface WalletWindow extends Window {
   freighterApi?: FreighterExtension;
   Horizon?: FreighterExtension;
 }
-const WalletStateContext = createContext<WalletStateContextType | null>(null);
-const WalletStatusContext = createContext<WalletStatusContextType | null>(null);
-const WalletActionsContext = createContext<WalletActionsContextType | null>(null);
+export const WalletStateContext = createContext<WalletStateContextType | null>(null);
+export const WalletStatusContext = createContext<WalletStatusContextType | null>(null);
+export const WalletActionsContext = createContext<WalletActionsContextType | null>(null);
 
 const CACHE_TTL = 2500;
 let cache: { expiresAt: number; value: WalletState | null } | null = null;

--- a/src/lib/transactionOps.ts
+++ b/src/lib/transactionOps.ts
@@ -37,6 +37,20 @@ export async function verifyOnLedger(hash?: string): Promise<boolean> {
 export async function submitTransaction(payload: Record<string, number>): Promise<string> {
   console.log("Preparing transaction with payload:", payload);
 
+  if (typeof window !== "undefined" && (window as any).__MOCK_TX_CONFIG__) {
+    const mockConfig = (window as any).__MOCK_TX_CONFIG__;
+    console.log("Mock Provider intercepted transaction:", payload);
+    
+    await new Promise((resolve) => setTimeout(resolve, mockConfig.delayMs || 1000));
+    
+    if (mockConfig.simulateFailure) {
+      throw new Error("Mock transaction failure simulated.");
+    }
+    
+    // Return fake hash
+    return "mock_tx_" + Math.random().toString(36).substring(2, 15);
+  }
+
   const { isConnected, getAddress } = await import("@stellar/freighter-api");
   const { Keypair, TransactionBuilder, Networks, Transaction } = await import("@stellar/stellar-sdk");
 


### PR DESCRIPTION

Closes #629

## Description
This pull request introduces a `MockWalletProvider` to seamlessly simulate a connected wallet environment and on-chain transactions without requiring a live Stellar testnet connection or the Freighter extension. This is especially useful for Storybook integration, UI unit testing, and design iterations.

### Technical Implementation Details
1. **Context Exporting in `WalletProvider.tsx`**
   - Exported the internal contexts (`WalletStateContext`, `WalletStatusContext`, `WalletActionsContext`) from the main `WalletProvider`. This allows `MockWalletProvider` to wrap and override these contexts exactly as the real provider does.

2. **New `MockWalletProvider.tsx`**
   - Implemented a configurable mock provider that lets you simulate:
     - The connection state and mock public keys.
     - Mock token balances.
     - Configurable transaction delays and failure scenarios via an internal window global config (`__MOCK_TX_CONFIG__`).
   - The provider can easily be injected into Storybook decorators.

3. **Transaction Interception in `transactionOps.ts`**
   - Updated the `submitTransaction` function to detect the `__MOCK_TX_CONFIG__` global variable. When present, it automatically intercepts the payload, simulates configurable artificial delay and/or failures, and bypasses the `Freighter API` / `Stellar SDK` logic altogether.

### Testing Instructions
1. Wrap any component with `<MockWalletProvider>` or set it up as a Storybook decorator.
2. Provide a custom configuration object to simulate a failure state, change the delay length, or provide custom pre-funded mock balances.
3. Validate that connected-state UI components render correctly without prompting the Freighter extension.
4. Try to submit a transaction; it should resolve using the mock values and delays instead of failing due to no connection.

***
# ⚠️  what is the line below this one?!
Let me know if you want any further adjustments to the mock provider!