### PR TITLE
🔊 Audio-Feedback | Optional Sound Effect Cues for Transaction Events

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -293,5 +293,10 @@
       <polyline points="16 17 21 12 16 7"/>
       <line x1="21" y1="12" x2="9" y2="12"/>
     </symbol>
+    <symbol id="icon-volume-2" viewBox="0 0 24 24">
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+    </symbol>
   </defs>
 </svg>

--- a/public/static/sprite.svg
+++ b/public/static/sprite.svg
@@ -293,5 +293,10 @@
       <polyline points="16 17 21 12 16 7"/>
       <line x1="21" y1="12" x2="9" y2="12"/>
     </symbol>
+    <symbol id="icon-volume-2" viewBox="0 0 24 24">
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+    </symbol>
   </defs>
 </svg>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { useDebounce } from '../hooks/useDebounce';
 import { useRafThrottle } from '../hooks/useRafThrottle';
 import { openPushPreferencesModal } from '@/components/notifications';
 import { loadPreferences } from '@/services/notifications';
+import { useTransactionAudio } from '@/hooks/useTransactionAudio';
 
 interface Settings {
   emailReports: boolean;
@@ -29,6 +30,7 @@ const TOGGLE_STYLES = {
 
 export default function SettingsPage() {
   const [showKey, setShowKey] = useState(false);
+  const { isEnabled: soundEffectsEnabled, toggle: toggleSoundEffects } = useTransactionAudio();
   const [settings, setSettings] = useState<Settings>({
     emailReports: true,
     pushNotifications: false,
@@ -152,12 +154,19 @@ export default function SettingsPage() {
               enabled={settings.pushNotifications}
               onToggle={() => handleToggle('pushNotifications')}
             />
-            <ToggleItem 
-              icon={<Icon id={ICON_IDS.globe} size={18} />} 
-              title="Public Status Page" 
+            <ToggleItem
+              icon={<Icon id={ICON_IDS.globe} size={18} />}
+              title="Public Status Page"
               description="Automatically update the status.stellarflow.io page."
               enabled={settings.publicStatusPage}
               onToggle={() => handleToggle('publicStatusPage')}
+            />
+            <ToggleItem
+              icon={<Icon id={ICON_IDS.volume2} size={18} />}
+              title="Sound Effects"
+              description="Play a chime when a transaction confirms or fails. Off by default."
+              enabled={soundEffectsEnabled}
+              onToggle={toggleSoundEffects}
             />
           </div>
         </section>

--- a/src/components/icons/iconIds.ts
+++ b/src/components/icons/iconIds.ts
@@ -79,6 +79,7 @@ export const ICON_IDS = {
   mailIcon:   "icon-mail",
   save:       "icon-save",
   rotateCcw:  "icon-rotate-ccw",
+  volume2:    "icon-volume-2",
 
   // Governance page
   xCircle:    "icon-x-circle",

--- a/src/components/ui/ToastQueue.tsx
+++ b/src/components/ui/ToastQueue.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useState, useCallback, useEffect, use
 import { AnimatePresence, motion } from "framer-motion";
 import Icon from "@/components/icons/Icon";
 import { ICON_IDS, IconId } from "@/components/icons/iconIds";
+import { useTransactionAudio } from "@/hooks/useTransactionAudio";
 
 export type ToastStatus = "submitted" | "processing" | "confirmed" | "failed";
 
@@ -45,6 +46,20 @@ export function useOptionalToast() {
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const timeouts = useRef<Record<string, NodeJS.Timeout>>({});
+  const { playSuccess, playFailure } = useTransactionAudio();
+
+  // Play a chime whenever a toast's status transitions to confirmed/failed,
+  // tracked outside of setState so the sound is a side effect, not a state
+  // update (avoids double-firing under React strict mode).
+  const lastPlayedStatus = useRef<Record<string, ToastStatus>>({});
+  useEffect(() => {
+    for (const toast of toasts) {
+      if (lastPlayedStatus.current[toast.id] === toast.status) continue;
+      lastPlayedStatus.current[toast.id] = toast.status;
+      if (toast.status === "confirmed") playSuccess();
+      else if (toast.status === "failed") playFailure();
+    }
+  }, [toasts, playSuccess, playFailure]);
 
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));

--- a/src/hooks/useTransactionAudio.ts
+++ b/src/hooks/useTransactionAudio.ts
@@ -1,0 +1,193 @@
+'use client';
+
+/**
+ * useTransactionAudio.ts
+ *
+ * Provides synthesized audio chimes for transaction events using the Web Audio API.
+ * No external dependencies — all sounds are synthesized at runtime.
+ *
+ * Chime design:
+ *   success  — two ascending tones  (C5 → E5, 80ms + 120ms, sine,     gain 0.3)
+ *   warning  — single mid tone      (A4,       200ms,        triangle, gain 0.25)
+ *   failure  — two descending tones (G4 → D4, 100ms + 150ms, sawtooth, gain 0.2)
+ *
+ * AudioContext is lazily initialized on first play call (browsers require a
+ * user gesture before creating an AudioContext).
+ *
+ * The enabled state is persisted to localStorage under the key 'sf_audio_enabled'.
+ * Defaults to disabled (false) per product spec.
+ *
+ * SSR-safe: all Web Audio API calls are guarded by `typeof window !== 'undefined'`.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'sf_audio_enabled';
+
+/** Read the persisted enabled flag (defaults to false = muted). */
+function readStoredEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    // Only return true if explicitly stored as 'true'
+    return stored === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the enabled flag to localStorage. */
+function writeStoredEnabled(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // Private browsing / storage quota — silently ignore
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Low-level synthesis helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OscillatorType = 'sine' | 'triangle' | 'sawtooth' | 'square';
+
+interface ToneParams {
+  frequency: number;
+  /** Duration in seconds */
+  duration: number;
+  type: OscillatorType;
+  gain: number;
+  /** Start time offset in seconds (relative to AudioContext.currentTime) */
+  startOffset: number;
+}
+
+/**
+ * Schedules a single synthesized tone via the Web Audio API.
+ * Uses a short linear ramp-down to prevent click artifacts at note end.
+ */
+function scheduleTone(ctx: AudioContext, params: ToneParams): void {
+  const { frequency, duration, type, gain, startOffset } = params;
+
+  const oscillator = ctx.createOscillator();
+  const gainNode = ctx.createGain();
+
+  oscillator.type = type;
+  oscillator.frequency.setValueAtTime(frequency, ctx.currentTime + startOffset);
+
+  gainNode.gain.setValueAtTime(gain, ctx.currentTime + startOffset);
+  // Soft release: ramp to zero over the last 10 ms to avoid clicks
+  const releaseStart = ctx.currentTime + startOffset + duration - 0.01;
+  gainNode.gain.linearRampToValueAtTime(0, releaseStart + 0.01);
+
+  oscillator.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  oscillator.start(ctx.currentTime + startOffset);
+  oscillator.stop(ctx.currentTime + startOffset + duration);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Note frequency constants (Hz)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NOTE = {
+  D4:  293.66,
+  G4:  392.00,
+  A4:  440.00,
+  C5:  523.25,
+  E5:  659.25,
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hook
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface UseTransactionAudioReturn {
+  playSuccess: () => void;
+  playWarning: () => void;
+  playFailure: () => void;
+  isEnabled: boolean;
+  toggle: () => void;
+}
+
+export function useTransactionAudio(): UseTransactionAudioReturn {
+  const [isEnabled, setIsEnabled] = useState<boolean>(readStoredEnabled);
+
+  /**
+   * Lazily-initialized AudioContext.  Stored in a ref so it persists across
+   * renders without causing re-renders and without being created on mount
+   * (which would violate the browser autoplay policy).
+   */
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  /** Returns the shared AudioContext, creating it on first call. */
+  const getAudioContext = useCallback((): AudioContext | null => {
+    if (typeof window === 'undefined') return null;
+    if (!audioCtxRef.current) {
+      try {
+        audioCtxRef.current = new AudioContext();
+      } catch {
+        // AudioContext not available (e.g. some sandboxed iframes)
+        return null;
+      }
+    }
+    // Resume context if it was suspended (e.g. after a period of inactivity)
+    if (audioCtxRef.current.state === 'suspended') {
+      audioCtxRef.current.resume().catch(() => {/* best-effort */});
+    }
+    return audioCtxRef.current;
+  }, []);
+
+  // ── Chime implementations ───────────────────────────────────────────────
+
+  /**
+   * Two ascending tones: C5 (80 ms) → E5 (120 ms)
+   * Sine wave, gain 0.3
+   */
+  const playSuccess = useCallback((): void => {
+    if (!isEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    scheduleTone(ctx, { frequency: NOTE.C5, duration: 0.08, type: 'sine', gain: 0.3, startOffset: 0 });
+    scheduleTone(ctx, { frequency: NOTE.E5, duration: 0.12, type: 'sine', gain: 0.3, startOffset: 0.08 });
+  }, [isEnabled, getAudioContext]);
+
+  /**
+   * Single mid tone: A4 (200 ms)
+   * Triangle wave, gain 0.25
+   */
+  const playWarning = useCallback((): void => {
+    if (!isEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    scheduleTone(ctx, { frequency: NOTE.A4, duration: 0.2, type: 'triangle', gain: 0.25, startOffset: 0 });
+  }, [isEnabled, getAudioContext]);
+
+  /**
+   * Two descending tones: G4 (100 ms) → D4 (150 ms)
+   * Sawtooth wave, gain 0.2
+   */
+  const playFailure = useCallback((): void => {
+    if (!isEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    scheduleTone(ctx, { frequency: NOTE.G4, duration: 0.1,  type: 'sawtooth', gain: 0.2, startOffset: 0 });
+    scheduleTone(ctx, { frequency: NOTE.D4, duration: 0.15, type: 'sawtooth', gain: 0.2, startOffset: 0.1 });
+  }, [isEnabled, getAudioContext]);
+
+  // ── Toggle ──────────────────────────────────────────────────────────────
+
+  const toggle = useCallback((): void => {
+    setIsEnabled((prev) => {
+      const next = !prev;
+      writeStoredEnabled(next);
+      return next;
+    });
+  }, []);
+
+  return { playSuccess, playWarning, playFailure, isEnabled, toggle };
+}


### PR DESCRIPTION
## Summary
- Adds `useTransactionAudio` (`src/hooks/useTransactionAudio.ts`), a hook that synthesizes success, warning, and failure chimes with the Web Audio API — no external audio files, so nothing to load over the network.
- `AudioContext` is created lazily on first play (never at mount) and reused, respecting the browser's autoplay/gesture policy.
- Wires success/failure chime playback into `ToastQueue` on the existing `confirmed`/`failed` toast status transitions (swap confirmed, transaction failed, etc.), tracked as a side effect (not inside `setState`) so it's safe under React strict mode.
- Adds a "Sound Effects" toggle to Settings → Alert Channels, defaulting to **disabled**, persisted to `localStorage` (`sf_audio_enabled`).
- Adds an `icon-volume-2` symbol to the shared SVG sprite for the new toggle row.

## Technical Requirements Addressed
- [x] Lightweight web audio synthesized chimes for success, warning, and failure states
- [x] Explicit global audio toggle setting (Mute/Unmute) defaulting to disabled
- [x] Load compressed audio assets lazily to prevent bundle overhead (no audio assets needed — synthesized at runtime, AudioContext created lazily)

## Files Changed
- `src/hooks/useTransactionAudio.ts` (new)
- `src/components/ui/ToastQueue.tsx`
- `src/app/settings/page.tsx`
- `src/components/icons/iconIds.ts`
- `public/sprite.svg`, `public/static/sprite.svg`

## Testing
- `npx tsc --noEmit` — no new type errors introduced.
- `npx eslint` on all changed files — clean.

Closes #627