### PR TITLE
Add Playwright visual regression snapshot tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,11 +21,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Build Next.js app
         run: npm run build
+
+      # Visual regression baselines (Issue #603): persisted as a CI artifact
+      # cache keyed on the spec file's contents so a first run auto-creates
+      # baselines and every subsequent run diffs against them. Bump the key
+      # (or commit updated PNGs under e2e/ once generated locally via
+      # `npm run test:visual:update`) to intentionally refresh baselines.
+      - name: Cache visual regression baselines
+        uses: actions/cache@v4
+        with:
+          path: e2e/visual.spec.ts-snapshots
+          key: visual-snapshots-${{ runner.os }}-${{ hashFiles('e2e/visual.spec.ts') }}
 
       - name: Run Playwright E2E tests
         run: npx playwright test
@@ -37,4 +60,12 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
+          retention-days: 7
+
+      - name: Upload visual diff artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-diffs
+          path: test-results/
           retention-days: 7

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Visual regression coverage (Issue #603)
+//
+// Captures full-page pixel-diff snapshots of the landing page at the core
+// responsive breakpoints so unexpected layout/UI regressions are caught in
+// CI before merge. Baselines live alongside this spec in
+// `visual.spec.ts-snapshots/` and are compared via Playwright's built-in
+// screenshot diffing (see `expect.toHaveScreenshot` config in
+// playwright.config.ts for the pixel-diff threshold).
+//
+// To (re)generate baselines locally: `npm run test:visual:update`
+
+const BREAKPOINTS = [
+  { name: 'mobile-375', width: 375, height: 812 },
+  { name: 'tablet-768', width: 768, height: 1024 },
+  { name: 'desktop-1440', width: 1440, height: 900 },
+] as const;
+
+async function prepareForSnapshot(page: Page) {
+  // Freeze CSS animations/transitions so timing differences between runs
+  // don't produce false-positive pixel diffs.
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  });
+}
+
+test.describe('Visual regression — landing page (Issue #603)', () => {
+  for (const breakpoint of BREAKPOINTS) {
+    test(`matches baseline at ${breakpoint.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: breakpoint.width, height: breakpoint.height });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+      await prepareForSnapshot(page);
+
+      await expect(page).toHaveScreenshot(`landing-${breakpoint.name}.png`, {
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "node scripts/test-lang-cache.js",
+    "test:e2e": "playwright test",
+    "test:visual": "playwright test e2e/visual.spec.ts",
+    "test:visual:update": "playwright test e2e/visual.spec.ts --update-snapshots",
     "analyze": "cross-env ANALYZE=true npm run build",
     "audit:ci": "npm audit --audit-level=high"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,15 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  // Pixel-diff tolerance for `expect(page).toHaveScreenshot()` visual
+  // regression tests — allows minor anti-aliasing/font-rendering drift
+  // between environments without masking real layout regressions.
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.02,
+      animations: 'disabled',
+    },
+  },
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- Adds `e2e/visual.spec.ts`: full-page pixel-diff screenshot tests of the landing page at the three core responsive breakpoints (Mobile 375px, Tablet 768px, Desktop 1440px), with animations/transitions frozen before each capture for deterministic diffs.
- Configures `expect.toHaveScreenshot` in `playwright.config.ts` with a 2% max pixel-diff ratio tolerance.
- Adds `test:e2e`, `test:visual`, and `test:visual:update` npm scripts (the latter for regenerating baselines locally).
- Updates `.github/workflows/e2e.yml` to cache Playwright's browser binaries and to persist visual baseline snapshots via a keyed `actions/cache` entry — first CI run auto-creates baselines, subsequent runs diff against them — plus uploads diff artifacts on failure for debugging.

Closes #603

## Notes
- This repo's build currently fails on `main` independent of this change (`ErrorBoundary` is not exported from `src/components/ui/index.ts`, referenced by `src/app/DashboardInteractive.tsx`), which also blocks `npm run build` in the existing e2e CI job. That's a pre-existing issue outside the scope of #603 — worth a follow-up fix so this workflow (and the new visual tests) can actually run in CI.
- No baseline PNGs are committed in this PR; per the design above they're generated by CI on first run and cached, or can be generated locally with `npm run test:visual:update` once the build issue above is resolved.

## Test plan
- [x] `npx eslint e2e/visual.spec.ts playwright.config.ts` passes
- [x] `npx tsc --noEmit` shows no new type errors
- [ ] `npm run test:visual` locally once the unrelated build failure noted above is fixed