### PR TITLE
Add portfolio tracker dashboard for aggregate asset & yield analytics

### DIFF
--- a/src/app/dashboard/portfolio/page.tsx
+++ b/src/app/dashboard/portfolio/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import PortfolioSummary from "@/components/analytics/PortfolioSummary";
+
+export default function PortfolioTrackerPage() {
+  return (
+    <div className="min-h-screen bg-neutral-950 p-6 text-neutral-100">
+      <div className="mb-8 border-b border-neutral-800 pb-6">
+        <h1 className="bg-gradient-to-r from-white to-neutral-400 bg-clip-text text-3xl font-bold tracking-tight text-transparent">
+          Portfolio Tracker
+        </h1>
+        <p className="mt-1 text-sm text-neutral-400">
+          Aggregate net worth, allocation, and yield performance across your
+          wallet, liquidity pools, and vaults.
+        </p>
+      </div>
+
+      <PortfolioSummary />
+    </div>
+  );
+}

--- a/src/app/hooks/usePortfolio.ts
+++ b/src/app/hooks/usePortfolio.ts
@@ -1,0 +1,114 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getCacheProfile } from "../lib/cacheProfiles";
+import type {
+  PortfolioHistoryPoint,
+  PortfolioSummaryData,
+  PortfolioTimeframe,
+} from "@/types/portfolio";
+
+function buildHistory(
+  days: number,
+  startValue: number,
+  endValue: number,
+): PortfolioHistoryPoint[] {
+  const points: PortfolioHistoryPoint[] = [];
+  const now = new Date();
+
+  for (let i = days; i >= 0; i -= Math.max(1, Math.floor(days / 24))) {
+    const date = new Date(now);
+    date.setDate(date.getDate() - i);
+
+    const progress = 1 - i / days;
+    // Deterministic gentle wobble so the line isn't perfectly straight.
+    const wobble = Math.sin(progress * Math.PI * 3) * (startValue * 0.015);
+    const netWorthUsd = startValue + (endValue - startValue) * progress + wobble;
+
+    points.push({
+      date: date.toISOString().split("T")[0],
+      netWorthUsd: Math.round(netWorthUsd * 100) / 100,
+    });
+  }
+
+  return points;
+}
+
+function getMockData(): PortfolioSummaryData {
+  const walletUsd = 8420.31;
+  const liquidityPoolsUsd = 5210.87;
+  const vaultsUsd = 3105.5;
+  const totalNetWorthUsd = walletUsd + liquidityPoolsUsd + vaultsUsd;
+
+  return {
+    totalNetWorthUsd,
+    changePercent24h: 2.37,
+    balances: { walletUsd, liquidityPoolsUsd, vaultsUsd },
+    allocation: [
+      { symbol: "XLM", assetClass: "native", valueUsd: 5680.4 },
+      { symbol: "USDC", assetClass: "native", valueUsd: 2739.91 },
+      { symbol: "XLM-USDC-LP", assetClass: "lp", valueUsd: 3420.6 },
+      { symbol: "NGN-XLM-LP", assetClass: "lp", valueUsd: 1790.27 },
+      { symbol: "Blue Chip Vault", assetClass: "vault", valueUsd: 1950.0 },
+      { symbol: "Stable Yield Vault", assetClass: "vault", valueUsd: 1155.5 },
+    ],
+    history: {
+      "7D": buildHistory(7, totalNetWorthUsd * 0.94, totalNetWorthUsd),
+      "30D": buildHistory(30, totalNetWorthUsd * 0.82, totalNetWorthUsd),
+      "90D": buildHistory(90, totalNetWorthUsd * 0.61, totalNetWorthUsd),
+      "1Y": buildHistory(365, totalNetWorthUsd * 0.35, totalNetWorthUsd),
+    },
+  };
+}
+
+const QUERY_KEY = ["portfolio-summary"] as const;
+
+export function usePortfolio(): UseQueryResult<PortfolioSummaryData, Error> {
+  const profile = getCacheProfile("portfolioSummary");
+
+  return useQuery<PortfolioSummaryData, Error>({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const res = await fetch("/api/portfolio", {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!res.ok) {
+        throw new Error(`Failed to fetch portfolio summary: ${res.status}`);
+      }
+
+      return res.json();
+    },
+    placeholderData: (prev) => prev,
+    staleTime: profile.staleTime,
+    gcTime: profile.gcTime,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}
+
+export function usePortfolioWithFallback(): {
+  data: PortfolioSummaryData;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: Error | null;
+} {
+  const query = usePortfolio();
+
+  if (query.data) {
+    return {
+      data: query.data,
+      isLoading: false,
+      isFetching: query.isFetching,
+      error: query.error,
+    };
+  }
+
+  return {
+    data: getMockData(),
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+  };
+}
+
+export type { PortfolioTimeframe };

--- a/src/app/lib/cacheProfiles.ts
+++ b/src/app/lib/cacheProfiles.ts
@@ -10,6 +10,9 @@ export const cacheProfiles = {
 
   // Periodic audit checks that don't need constant updates
   validatorAudit: getCacheOptions('MEDIUM_INTERVAL'),
+
+  // Aggregate wallet/LP/vault balances backing the portfolio dashboard.
+  portfolioSummary: getCacheOptions('MEDIUM_INTERVAL'),
 } as const;
 
 export type CacheProfile = keyof typeof cacheProfiles;

--- a/src/components/analytics/PortfolioAllocationChart.tsx
+++ b/src/components/analytics/PortfolioAllocationChart.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Chart,
+  ArcElement,
+  DoughnutController,
+  Tooltip,
+  type ChartConfiguration,
+} from "chart.js";
+import type { PortfolioAllocationSlice } from "@/types/portfolio";
+
+Chart.register(ArcElement, DoughnutController, Tooltip);
+
+const SLICE_COLORS = [
+  "#60a5fa",
+  "#34d399",
+  "#f59e0b",
+  "#f472b6",
+  "#a78bfa",
+  "#22d3ee",
+  "#fb923c",
+  "#4ade80",
+];
+
+interface PortfolioAllocationChartProps {
+  allocation: PortfolioAllocationSlice[];
+}
+
+function formatUsd(value: number): string {
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}
+
+export default function PortfolioAllocationChart({
+  allocation,
+}: PortfolioAllocationChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const chartRef = useRef<Chart<"doughnut"> | null>(null);
+  const [hiddenSymbols, setHiddenSymbols] = useState<Set<string>>(new Set());
+
+  const total = useMemo(
+    () => allocation.reduce((sum, slice) => sum + slice.valueUsd, 0),
+    [allocation],
+  );
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const config: ChartConfiguration<"doughnut"> = {
+      type: "doughnut",
+      data: {
+        labels: allocation.map((slice) => slice.symbol),
+        datasets: [
+          {
+            data: allocation.map((slice) => slice.valueUsd),
+            backgroundColor: allocation.map(
+              (_, index) => SLICE_COLORS[index % SLICE_COLORS.length],
+            ),
+            borderColor: "#161b22",
+            borderWidth: 2,
+            hoverOffset: 8,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: "68%",
+        animation: { duration: 250 },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const value = context.parsed as number;
+                const pct = total > 0 ? (value / total) * 100 : 0;
+                return `${context.label}: ${formatUsd(value)} (${pct.toFixed(1)}%)`;
+              },
+            },
+          },
+        },
+      },
+    };
+
+    chartRef.current = new Chart(canvasRef.current, config);
+
+    return () => {
+      chartRef.current?.destroy();
+      chartRef.current = null;
+    };
+  }, [allocation, total]);
+
+  const toggleSlice = (symbol: string, index: number) => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    chart.toggleDataVisibility(index);
+    chart.update();
+
+    setHiddenSymbols((prev) => {
+      const next = new Set(prev);
+      if (next.has(symbol)) {
+        next.delete(symbol);
+      } else {
+        next.add(symbol);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+      <div className="relative mx-auto h-48 w-48 shrink-0 sm:mx-0">
+        <canvas ref={canvasRef} aria-label="Portfolio allocation by asset" />
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+            Total
+          </span>
+          <span className="font-mono text-lg font-bold text-neutral-100">
+            {formatUsd(total)}
+          </span>
+        </div>
+      </div>
+
+      <ul className="flex-1 space-y-2">
+        {allocation.map((slice, index) => {
+          const isHidden = hiddenSymbols.has(slice.symbol);
+          const pct = total > 0 ? (slice.valueUsd / total) * 100 : 0;
+
+          return (
+            <li key={slice.symbol}>
+              <button
+                type="button"
+                onClick={() => toggleSlice(slice.symbol, index)}
+                className={`flex w-full items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm transition-opacity hover:bg-neutral-800/60 ${
+                  isHidden ? "opacity-40" : ""
+                }`}
+              >
+                <span className="flex items-center gap-2 text-neutral-300">
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: SLICE_COLORS[index % SLICE_COLORS.length],
+                    }}
+                  />
+                  {slice.symbol}
+                </span>
+                <span className="font-mono text-xs text-neutral-500">
+                  {pct.toFixed(1)}%
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/analytics/PortfolioHistoryChart.tsx
+++ b/src/components/analytics/PortfolioHistoryChart.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Chart,
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Filler,
+  Tooltip,
+  type ChartConfiguration,
+} from "chart.js";
+import type { PortfolioSummaryData, PortfolioTimeframe } from "@/types/portfolio";
+
+Chart.register(
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Filler,
+  Tooltip,
+);
+
+const TIMEFRAMES: PortfolioTimeframe[] = ["7D", "30D", "90D", "1Y"];
+
+interface PortfolioHistoryChartProps {
+  history: PortfolioSummaryData["history"];
+}
+
+function formatUsd(value: number): string {
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatLabel(date: string, timeframe: PortfolioTimeframe): string {
+  const parsed = new Date(date);
+  if (timeframe === "1Y") {
+    return parsed.toLocaleDateString(undefined, { month: "short" });
+  }
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export default function PortfolioHistoryChart({
+  history,
+}: PortfolioHistoryChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const chartRef = useRef<Chart<"line"> | null>(null);
+  const [timeframe, setTimeframe] = useState<PortfolioTimeframe>("30D");
+
+  const points = history[timeframe];
+
+  const { changeUsd, changePercent } = useMemo(() => {
+    if (points.length < 2) return { changeUsd: 0, changePercent: 0 };
+    const first = points[0].netWorthUsd;
+    const last = points[points.length - 1].netWorthUsd;
+    return {
+      changeUsd: last - first,
+      changePercent: first !== 0 ? ((last - first) / first) * 100 : 0,
+    };
+  }, [points]);
+
+  const isPositive = changeUsd >= 0;
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const config: ChartConfiguration<"line"> = {
+      type: "line",
+      data: {
+        labels: points.map((point) => formatLabel(point.date, timeframe)),
+        datasets: [
+          {
+            label: "Net Worth",
+            data: points.map((point) => point.netWorthUsd),
+            borderColor: isPositive ? "#34d399" : "#f87171",
+            backgroundColor: isPositive
+              ? "rgba(52, 211, 153, 0.12)"
+              : "rgba(248, 113, 113, 0.12)",
+            fill: true,
+            tension: 0.35,
+            pointRadius: 0,
+            pointHoverRadius: 4,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: { duration: 200 },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (context) => formatUsd(context.parsed.y as number),
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: { color: "rgba(255,255,255,0.06)" },
+            ticks: {
+              color: "rgba(255,255,255,0.45)",
+              maxTicksLimit: 8,
+              autoSkip: true,
+            },
+          },
+          y: {
+            grid: { color: "rgba(255,255,255,0.06)" },
+            ticks: {
+              color: "rgba(255,255,255,0.45)",
+              callback: (value) => formatUsd(value as number),
+            },
+          },
+        },
+      },
+    };
+
+    chartRef.current = new Chart(canvasRef.current, config);
+
+    return () => {
+      chartRef.current?.destroy();
+      chartRef.current = null;
+    };
+  }, [points, timeframe, isPositive]);
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <span
+          className={`font-mono text-sm ${isPositive ? "text-emerald-400" : "text-red-400"}`}
+        >
+          {isPositive ? "+" : ""}
+          {formatUsd(changeUsd)} ({isPositive ? "+" : ""}
+          {changePercent.toFixed(2)}%) · {timeframe}
+        </span>
+
+        <div className="flex items-center gap-1 rounded-lg border border-neutral-800 bg-neutral-950 p-1">
+          {TIMEFRAMES.map((tf) => (
+            <button
+              key={tf}
+              type="button"
+              onClick={() => setTimeframe(tf)}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                timeframe === tf
+                  ? "bg-neutral-800 text-neutral-100"
+                  : "text-neutral-500 hover:text-neutral-300"
+              }`}
+            >
+              {tf}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="h-64 w-full">
+        <canvas ref={canvasRef} aria-label="Portfolio net worth history" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/PortfolioSummary.tsx
+++ b/src/components/analytics/PortfolioSummary.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { PieChart, Wallet, Droplets, Vault } from "lucide-react";
+import { usePortfolioWithFallback } from "@/app/hooks/usePortfolio";
+import PortfolioAllocationChart from "./PortfolioAllocationChart";
+import PortfolioHistoryChart from "./PortfolioHistoryChart";
+
+function formatUsd(value: number): string {
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+}
+
+export default function PortfolioSummary() {
+  const { data, isLoading, isFetching } = usePortfolioWithFallback();
+  const { totalNetWorthUsd, changePercent24h, balances, allocation, history } = data;
+  const isPositive24h = changePercent24h >= 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <span className="text-xs uppercase tracking-wider text-neutral-500">
+              Total Net Worth
+            </span>
+            <div className="mt-1 flex items-baseline gap-3">
+              <span className="font-mono text-4xl font-bold text-neutral-100">
+                {isLoading ? "—" : formatUsd(totalNetWorthUsd)}
+              </span>
+              <span
+                className={`font-mono text-sm font-semibold ${
+                  isPositive24h ? "text-emerald-400" : "text-red-400"
+                }`}
+              >
+                {isPositive24h ? "+" : ""}
+                {changePercent24h.toFixed(2)}% (24h)
+              </span>
+            </div>
+          </div>
+
+          <span
+            className={`h-2 w-2 rounded-full ${
+              isFetching ? "animate-pulse bg-amber-500" : "bg-emerald-500"
+            }`}
+            aria-hidden
+          />
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <BalanceCard
+            icon={<Wallet size={16} className="text-blue-400" />}
+            label="Wallet"
+            valueUsd={balances.walletUsd}
+          />
+          <BalanceCard
+            icon={<Droplets size={16} className="text-cyan-400" />}
+            label="Liquidity Pools"
+            valueUsd={balances.liquidityPoolsUsd}
+          />
+          <BalanceCard
+            icon={<Vault size={16} className="text-purple-400" />}
+            label="Vaults"
+            valueUsd={balances.vaultsUsd}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-5 xl:col-span-2">
+          <h2 className="mb-4 text-lg font-semibold text-neutral-200">
+            Net Worth History
+          </h2>
+          <PortfolioHistoryChart history={history} />
+        </div>
+
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-5">
+          <div className="mb-4 flex items-center gap-2">
+            <PieChart size={16} className="text-neutral-400" />
+            <h2 className="text-lg font-semibold text-neutral-200">Allocation</h2>
+          </div>
+          <PortfolioAllocationChart allocation={allocation} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BalanceCard({
+  icon,
+  label,
+  valueUsd,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  valueUsd: number;
+}) {
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-950/50 p-4">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-neutral-500">
+        {icon}
+        {label}
+      </div>
+      <span className="mt-1 block font-mono text-xl font-semibold text-neutral-100">
+        {formatUsd(valueUsd)}
+      </span>
+    </div>
+  );
+}

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -1,0 +1,3 @@
+export { default as PortfolioSummary } from "./PortfolioSummary";
+export { default as PortfolioAllocationChart } from "./PortfolioAllocationChart";
+export { default as PortfolioHistoryChart } from "./PortfolioHistoryChart";

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -1,0 +1,37 @@
+/**
+ * Aggregate portfolio types backing the portfolio tracker dashboard —
+ * net worth, allocation across wallet/LP/vault positions, and historical
+ * balance growth.
+ */
+
+export type PortfolioAssetClass = "native" | "lp" | "vault";
+
+export interface PortfolioAllocationSlice {
+  /** Token or position symbol, e.g. "XLM", "XLM-USDC-LP", "Blue Chip Vault". */
+  symbol: string;
+  assetClass: PortfolioAssetClass;
+  valueUsd: number;
+}
+
+export type PortfolioTimeframe = "7D" | "30D" | "90D" | "1Y";
+
+export interface PortfolioHistoryPoint {
+  /** ISO-8601 date, e.g. "2026-07-15". */
+  date: string;
+  netWorthUsd: number;
+}
+
+export interface PortfolioBalanceBreakdown {
+  walletUsd: number;
+  liquidityPoolsUsd: number;
+  vaultsUsd: number;
+}
+
+export interface PortfolioSummaryData {
+  totalNetWorthUsd: number;
+  /** Change over the last 24h, as a percentage (e.g. 2.4 for +2.4%). */
+  changePercent24h: number;
+  balances: PortfolioBalanceBreakdown;
+  allocation: PortfolioAllocationSlice[];
+  history: Record<PortfolioTimeframe, PortfolioHistoryPoint[]>;
+}


### PR DESCRIPTION
## Summary
- Adds `PortfolioSummary` (`src/components/analytics/PortfolioSummary.tsx`): total net worth header with 24h change, and a wallet/liquidity-pool/vault balance breakdown.
- Adds `PortfolioAllocationChart`: an interactive doughnut chart (chart.js) breaking down allocation by token/position, with a clickable legend that toggles slices and shows live percentages.
- Adds `PortfolioHistoryChart`: a net-worth line chart with 7D/30D/90D/1Y timeframe switching and period change summary.
- Adds a `usePortfolio` react-query hook (mock-data fallback, following the existing `useCorridorMetrics` pattern) since there was no portfolio/balance data source in the app yet — the referenced `api.getPortfolio()` stub has no backing route.
- Wires everything up on a new `/dashboard/portfolio` page, following the existing `/dashboard/corridors` layout conventions.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx eslint` on all changed files — clean
- [x] Verified `/dashboard/portfolio` renders net worth, balance cards, history chart with timeframe switching, and the allocation donut in a local dev server

Closes #606